### PR TITLE
feat(notifications): add in-app notification center with real-time Websocket

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -35,6 +35,7 @@ import { CdnModule } from './modules/cdn/cdn.module';
 import { FilesModule } from './modules/files/files.module';
 import { RealtimeModule } from './modules/realtime/realtime.module';
 import { WalletsModule } from './modules/wallets/wallets.module';
+import { NotificationsModule } from './modules/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -90,8 +91,10 @@ import { WalletsModule } from './modules/wallets/wallets.module';
     FilesModule,
     RealtimeModule,
     WalletsModule,
+    // Notifications
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule { }

--- a/backend/src/modules/notifications/dto/notifications.dto.ts
+++ b/backend/src/modules/notifications/dto/notifications.dto.ts
@@ -1,0 +1,128 @@
+import {
+    IsEnum,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    IsBoolean,
+    IsArray,
+    IsUUID,
+    IsUrl,
+    IsInt,
+    Min,
+    Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { NotificationCategory } from '../entities/notification.entity';
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+export class CreateNotificationDto {
+    @IsString()
+    @IsNotEmpty()
+    userId: string;
+
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+
+    @IsString()
+    @IsNotEmpty()
+    message: string;
+
+    @IsEnum(NotificationCategory)
+    category: NotificationCategory;
+
+    @IsUrl()
+    @IsOptional()
+    actionUrl?: string;
+
+    @IsOptional()
+    metadata?: Record<string, unknown>;
+}
+
+// ── Query / Filtering ─────────────────────────────────────────────────────────
+
+export class NotificationQueryDto {
+    @IsEnum(NotificationCategory)
+    @IsOptional()
+    category?: NotificationCategory;
+
+    @IsBoolean()
+    @IsOptional()
+    @Type(() => Boolean)
+    isRead?: boolean;
+
+    @IsInt()
+    @Min(1)
+    @IsOptional()
+    @Type(() => Number)
+    page?: number = 1;
+
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    @IsOptional()
+    @Type(() => Number)
+    limit?: number = 20;
+}
+
+// ── Bulk Actions ──────────────────────────────────────────────────────────────
+
+export enum BulkAction {
+    MARK_READ = 'MARK_READ',
+    MARK_UNREAD = 'MARK_UNREAD',
+    DELETE = 'DELETE',
+}
+
+export class BulkActionDto {
+    @IsArray()
+    @IsUUID('4', { each: true })
+    ids: string[];
+
+    @IsEnum(BulkAction)
+    action: BulkAction;
+}
+
+// ── Settings ──────────────────────────────────────────────────────────────────
+
+export class UpdateNotificationSettingDto {
+    @IsBoolean()
+    @IsOptional()
+    globalEnabled?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    appointment?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    medication?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    consultation?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    alert?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    message?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    vaccination?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    lostPet?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    medicalRecord?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    system?: boolean;
+}

--- a/backend/src/modules/notifications/entities/notification-setting.entity.ts
+++ b/backend/src/modules/notifications/entities/notification-setting.entity.ts
@@ -1,0 +1,55 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+    UpdateDateColumn,
+    Index,
+} from 'typeorm';
+
+@Entity('notification_settings')
+@Index(['userId'], { unique: true })
+export class NotificationSetting {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'varchar' })
+    userId: string;
+
+    /** Master switch — if false, no in-app notifications are shown */
+    @Column({ type: 'boolean', default: true })
+    globalEnabled: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    appointment: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    medication: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    consultation: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    alert: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    message: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    vaccination: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    lostPet: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    medicalRecord: boolean;
+
+    @Column({ type: 'boolean', default: true })
+    system: boolean;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/backend/src/modules/notifications/entities/notification.entity.ts
+++ b/backend/src/modules/notifications/entities/notification.entity.ts
@@ -1,0 +1,61 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+    UpdateDateColumn,
+    Index,
+} from 'typeorm';
+
+export enum NotificationCategory {
+    APPOINTMENT = 'APPOINTMENT',
+    MEDICATION = 'MEDICATION',
+    CONSULTATION = 'CONSULTATION',
+    ALERT = 'ALERT',
+    MESSAGE = 'MESSAGE',
+    VACCINATION = 'VACCINATION',
+    LOST_PET = 'LOST_PET',
+    MEDICAL_RECORD = 'MEDICAL_RECORD',
+    SYSTEM = 'SYSTEM',
+}
+
+@Entity('notifications')
+@Index(['userId', 'isRead'])
+@Index(['userId', 'category'])
+@Index(['userId', 'createdAt'])
+export class Notification {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'varchar' })
+    userId: string;
+
+    @Column({ type: 'varchar' })
+    title: string;
+
+    @Column({ type: 'text' })
+    message: string;
+
+    @Column({ type: 'enum', enum: NotificationCategory })
+    category: NotificationCategory;
+
+    @Column({ type: 'boolean', default: false })
+    isRead: boolean;
+
+    @Column({ type: 'timestamp', nullable: true })
+    readAt: Date | null;
+
+    /** Optional deep-link or action URL */
+    @Column({ type: 'varchar', nullable: true })
+    actionUrl: string | null;
+
+    /** Any extra data (petId, appointmentId, etc.) */
+    @Column({ type: 'jsonb', nullable: true })
+    metadata: Record<string, unknown> | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,118 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Patch,
+    Delete,
+    Body,
+    Param,
+    Query,
+    HttpCode,
+    HttpStatus,
+} from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import {
+    CreateNotificationDto,
+    NotificationQueryDto,
+    BulkActionDto,
+    UpdateNotificationSettingDto,
+} from './dto/notifications.dto';
+
+/**
+ * NotificationsController
+ * -----------------------
+ * All routes are prefixed /notifications
+ *
+ * In production, guard these with your JwtAuthGuard and derive
+ * userId from req.user.id rather than a route param.
+ *
+ * REST API:
+ *   POST   /notifications                         → create
+ *   GET    /notifications/:userId                 → list (filtered, paginated)
+ *   PATCH  /notifications/:userId/bulk            → bulk action
+ *   PATCH  /notifications/:userId/read-all        → mark all read
+ *   GET    /notifications/:userId/settings        → get settings
+ *   PATCH  /notifications/:userId/settings        → update settings
+ *   GET    /notifications/:userId/:id             → get single
+ *   PATCH  /notifications/:userId/:id/read        → mark read
+ *   PATCH  /notifications/:userId/:id/unread      → mark unread
+ *   DELETE /notifications/:userId/:id             → delete one
+ */
+@Controller('notifications')
+export class NotificationsController {
+    constructor(private readonly notificationsService: NotificationsService) { }
+
+    // ── Create ──────────────────────────────────────────────────────────────────
+
+    @Post()
+    create(@Body() dto: CreateNotificationDto) {
+        return this.notificationsService.create(dto);
+    }
+
+    // ── List ────────────────────────────────────────────────────────────────────
+
+    @Get(':userId')
+    findAll(
+        @Param('userId') userId: string,
+        @Query() query: NotificationQueryDto,
+    ) {
+        return this.notificationsService.findAll(userId, query);
+    }
+
+    // ── Bulk actions ────────────────────────────────────────────────────────────
+
+    @Patch(':userId/bulk')
+    @HttpCode(HttpStatus.OK)
+    bulkAction(
+        @Param('userId') userId: string,
+        @Body() dto: BulkActionDto,
+    ) {
+        return this.notificationsService.bulkAction(userId, dto);
+    }
+
+    // ── Mark all read ───────────────────────────────────────────────────────────
+
+    @Patch(':userId/read-all')
+    @HttpCode(HttpStatus.OK)
+    markAllAsRead(@Param('userId') userId: string) {
+        return this.notificationsService.markAllAsRead(userId);
+    }
+
+    // ── Settings ────────────────────────────────────────────────────────────────
+
+    @Get(':userId/settings')
+    getSettings(@Param('userId') userId: string) {
+        return this.notificationsService.getSettings(userId);
+    }
+
+    @Patch(':userId/settings')
+    updateSettings(
+        @Param('userId') userId: string,
+        @Body() dto: UpdateNotificationSettingDto,
+    ) {
+        return this.notificationsService.updateSettings(userId, dto);
+    }
+
+    // ── Single notification ──────────────────────────────────────────────────────
+
+    @Get(':userId/:id')
+    findOne(@Param('id') id: string, @Param('userId') userId: string) {
+        return this.notificationsService.findOne(id, userId);
+    }
+
+    @Patch(':userId/:id/read')
+    markAsRead(@Param('id') id: string, @Param('userId') userId: string) {
+        return this.notificationsService.markAsRead(id, userId);
+    }
+
+    @Patch(':userId/:id/unread')
+    markAsUnread(@Param('id') id: string, @Param('userId') userId: string) {
+        return this.notificationsService.markAsUnread(id, userId);
+    }
+
+    @Delete(':userId/:id')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    remove(@Param('id') id: string, @Param('userId') userId: string) {
+        return this.notificationsService.remove(id, userId);
+    }
+}

--- a/backend/src/modules/notifications/notifications.module.ts
+++ b/backend/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,18 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Notification } from './entities/notification.entity';
+import { NotificationSetting } from './entities/notification-setting.entity';
+import { NotificationsService } from './notifications.service';
+import { NotificationsController } from './notifications.controller';
+import { WebSocketModule } from 'src/websocket/websocket.module';
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([Notification, NotificationSetting]),
+        forwardRef(() => WebSocketModule),
+    ],
+    controllers: [NotificationsController],
+    providers: [NotificationsService],
+    exports: [NotificationsService],
+})
+export class NotificationsModule { }

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,260 @@
+import {
+    Injectable,
+    Logger,
+    NotFoundException,
+    ForbiddenException,
+    forwardRef,
+    Inject,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import {
+    Notification,
+    NotificationCategory,
+} from './entities/notification.entity';
+import { NotificationSetting } from './entities/notification-setting.entity';
+import {
+    CreateNotificationDto,
+    NotificationQueryDto,
+    BulkActionDto,
+    BulkAction,
+    UpdateNotificationSettingDto,
+} from './dto/notifications.dto';
+import { NotificationsGateway } from 'src/websocket/gateways/notifications.gateway';
+
+/** Maps NotificationCategory to the setting column name */
+const CATEGORY_TO_SETTING: Record<NotificationCategory, keyof NotificationSetting> = {
+    [NotificationCategory.APPOINTMENT]: 'appointment',
+    [NotificationCategory.MEDICATION]: 'medication',
+    [NotificationCategory.CONSULTATION]: 'consultation',
+    [NotificationCategory.ALERT]: 'alert',
+    [NotificationCategory.MESSAGE]: 'message',
+    [NotificationCategory.VACCINATION]: 'vaccination',
+    [NotificationCategory.LOST_PET]: 'lostPet',
+    [NotificationCategory.MEDICAL_RECORD]: 'medicalRecord',
+    [NotificationCategory.SYSTEM]: 'system',
+};
+
+@Injectable()
+export class NotificationsService {
+    private readonly logger = new Logger(NotificationsService.name);
+
+    constructor(
+        @InjectRepository(Notification)
+        private readonly notificationRepo: Repository<Notification>,
+        @InjectRepository(NotificationSetting)
+        private readonly settingRepo: Repository<NotificationSetting>,
+        @Inject(forwardRef(() => NotificationsGateway))
+        private readonly gateway: NotificationsGateway,
+    ) { }
+
+    // ── Create ──────────────────────────────────────────────────────────────────
+
+    async create(dto: CreateNotificationDto): Promise<Notification> {
+        // Check user settings — skip if category is disabled
+        const allowed = await this.isCategoryAllowed(dto.userId, dto.category);
+        if (!allowed) {
+            this.logger.log(
+                `Notification skipped for user ${dto.userId} — category ${dto.category} disabled`,
+            );
+            // Return a transient (unsaved) object so callers don't break
+            return this.notificationRepo.create({ ...dto, isRead: false });
+        }
+
+        const notification = this.notificationRepo.create({
+            userId: dto.userId,
+            title: dto.title,
+            message: dto.message,
+            category: dto.category,
+            actionUrl: dto.actionUrl ?? null,
+            metadata: dto.metadata ?? null,
+            isRead: false,
+        });
+
+        await this.notificationRepo.save(notification);
+        this.logger.log(`Created notification ${notification.id} for user ${dto.userId}`);
+
+        // Push real-time via WebSocket
+        await this.gateway.sendNotification(dto.userId, {
+            type: dto.category as any,
+            title: dto.title,
+            message: dto.message,
+            targetUserId: dto.userId,
+            metadata: dto.metadata,
+        });
+
+        return notification;
+    }
+
+    // ── Read ────────────────────────────────────────────────────────────────────
+
+    async findAll(
+        userId: string,
+        query: NotificationQueryDto,
+    ): Promise<{ data: Notification[]; total: number; unreadCount: number }> {
+        const { category, isRead, page = 1, limit = 20 } = query;
+
+        const qb = this.notificationRepo
+            .createQueryBuilder('n')
+            .where('n.userId = :userId', { userId })
+            .orderBy('n.createdAt', 'DESC')
+            .skip((page - 1) * limit)
+            .take(limit);
+
+        if (category) qb.andWhere('n.category = :category', { category });
+        if (isRead !== undefined) qb.andWhere('n.isRead = :isRead', { isRead });
+
+        const [data, total] = await qb.getManyAndCount();
+        const unreadCount = await this.notificationRepo.count({
+            where: { userId, isRead: false },
+        });
+
+        return { data, total, unreadCount };
+    }
+
+    async findOne(id: string, userId: string): Promise<Notification> {
+        const notification = await this.notificationRepo.findOne({ where: { id } });
+        if (!notification) throw new NotFoundException(`Notification ${id} not found`);
+        if (notification.userId !== userId) throw new ForbiddenException();
+        return notification;
+    }
+
+    // ── Mark read / unread ──────────────────────────────────────────────────────
+
+    async markAsRead(id: string, userId: string): Promise<Notification> {
+        const notification = await this.findOne(id, userId);
+        if (notification.isRead) return notification;
+
+        notification.isRead = true;
+        notification.readAt = new Date();
+        await this.notificationRepo.save(notification);
+
+        await this.pushUnreadCount(userId);
+        return notification;
+    }
+
+    async markAsUnread(id: string, userId: string): Promise<Notification> {
+        const notification = await this.findOne(id, userId);
+        if (!notification.isRead) return notification;
+
+        notification.isRead = false;
+        notification.readAt = null;
+        await this.notificationRepo.save(notification);
+
+        await this.pushUnreadCount(userId);
+        return notification;
+    }
+
+    async markAllAsRead(userId: string): Promise<{ updated: number }> {
+        const result = await this.notificationRepo.update(
+            { userId, isRead: false },
+            { isRead: true, readAt: new Date() },
+        );
+        await this.pushUnreadCount(userId);
+        return { updated: result.affected ?? 0 };
+    }
+
+    // ── Bulk actions ────────────────────────────────────────────────────────────
+
+    async bulkAction(userId: string, dto: BulkActionDto): Promise<{ affected: number }> {
+        // Ensure all ids belong to the requesting user
+        const owned = await this.notificationRepo.find({
+            where: { id: In(dto.ids), userId },
+            select: ['id'],
+        });
+
+        if (owned.length === 0) return { affected: 0 };
+        const ownedIds = owned.map((n) => n.id);
+
+        let affected = 0;
+
+        switch (dto.action) {
+            case BulkAction.MARK_READ: {
+                const result = await this.notificationRepo.update(
+                    { id: In(ownedIds), isRead: false },
+                    { isRead: true, readAt: new Date() },
+                );
+                affected = result.affected ?? 0;
+                break;
+            }
+            case BulkAction.MARK_UNREAD: {
+                const result = await this.notificationRepo.update(
+                    { id: In(ownedIds), isRead: true },
+                    { isRead: false, readAt: null },
+                );
+                affected = result.affected ?? 0;
+                break;
+            }
+            case BulkAction.DELETE: {
+                const result = await this.notificationRepo.delete({ id: In(ownedIds) });
+                affected = result.affected ?? 0;
+                break;
+            }
+        }
+
+        await this.pushUnreadCount(userId);
+        this.logger.log(`Bulk ${dto.action} — ${affected} notifications for user ${userId}`);
+        return { affected };
+    }
+
+    // ── Delete ──────────────────────────────────────────────────────────────────
+
+    async remove(id: string, userId: string): Promise<void> {
+        const notification = await this.findOne(id, userId);
+        await this.notificationRepo.remove(notification);
+        await this.pushUnreadCount(userId);
+    }
+
+    // ── Settings ────────────────────────────────────────────────────────────────
+
+    async getSettings(userId: string): Promise<NotificationSetting> {
+        let setting = await this.settingRepo.findOne({ where: { userId } });
+        if (!setting) {
+            setting = this.settingRepo.create({ userId });
+            await this.settingRepo.save(setting);
+        }
+        return setting;
+    }
+
+    async updateSettings(
+        userId: string,
+        dto: UpdateNotificationSettingDto,
+    ): Promise<NotificationSetting> {
+        let setting = await this.settingRepo.findOne({ where: { userId } });
+        if (!setting) {
+            setting = this.settingRepo.create({ userId });
+        }
+        Object.assign(setting, dto);
+        await this.settingRepo.save(setting);
+        this.logger.log(`Updated notification settings for user ${userId}`);
+        return setting;
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private async isCategoryAllowed(
+        userId: string,
+        category: NotificationCategory,
+    ): Promise<boolean> {
+        const setting = await this.settingRepo.findOne({ where: { userId } });
+        if (!setting) return true; // no record = all allowed
+
+        if (!setting.globalEnabled) return false;
+
+        const key = CATEGORY_TO_SETTING[category];
+        return Boolean(setting[key]);
+    }
+
+    private async pushUnreadCount(userId: string): Promise<void> {
+        const unreadCount = await this.notificationRepo.count({
+            where: { userId, isRead: false },
+        });
+        await this.gateway.sendNotification(userId, {
+            type: 'UNREAD_COUNT' as any,
+            title: 'unread_count',
+            message: String(unreadCount),
+            targetUserId: userId,
+            metadata: { unreadCount },
+        });
+    }
+}

--- a/backend/src/websocket/gateways/notifications.gateway.ts
+++ b/backend/src/websocket/gateways/notifications.gateway.ts
@@ -8,12 +8,14 @@ import {
   MessageBody,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger, UseGuards } from '@nestjs/common';
+import { forwardRef, Inject, Logger, UseGuards } from '@nestjs/common';
 import { WebSocketConnectionService } from '../services/websocket-connection.service';
 import { MessageQueueService } from '../services/message-queue.service';
 import { WebSocketRateLimitService } from '../services/websocket-rate-limit.service';
 import { NotificationDto } from '../dto/notification.dto';
 import { WsAuthGuard } from '../guards/ws-auth.guard';
+import { BulkActionDto, NotificationQueryDto } from 'src/modules/notifications/dto/notifications.dto';
+import { NotificationsService } from 'src/modules/notifications/notifications.service';
 
 @WebSocketGateway({
   cors: { origin: '*' },
@@ -21,8 +23,7 @@ import { WsAuthGuard } from '../guards/ws-auth.guard';
 })
 @UseGuards(WsAuthGuard)
 export class NotificationsGateway
-  implements OnGatewayConnection, OnGatewayDisconnect
-{
+  implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
 
@@ -32,7 +33,9 @@ export class NotificationsGateway
     private connectionService: WebSocketConnectionService,
     private messageQueueService: MessageQueueService,
     private rateLimitService: WebSocketRateLimitService,
-  ) {}
+    @Inject(forwardRef(() => NotificationsService))
+    private notificationsService: NotificationsService,
+  ) { }
 
   async handleConnection(client: Socket) {
     const userId = client.handshake.auth.userId || client.id;
@@ -71,15 +74,83 @@ export class NotificationsGateway
     return { event: 'pong', data: { timestamp: Date.now() } };
   }
 
+  /**
+   * Client emits 'get-notifications' to fetch their notification list.
+   * Payload: NotificationQueryDto (category, isRead, page, limit)
+   *
+   * Server responds with 'notifications-list' event.
+   */
+  @SubscribeMessage('get-notifications')
+  async handleGetNotifications(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() query: NotificationQueryDto,
+  ) {
+    const userId = client.handshake.auth.userId || client.id;
+    const result = await this.notificationsService.findAll(userId, query);
+    client.emit('notifications-list', result);
+  }
+
+  /**
+   * Client emits 'mark-read' with { id: string }
+   * Server responds with 'notification-updated' event.
+   */
+  @SubscribeMessage('mark-read')
+  async handleMarkRead(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: { id: string },
+  ) {
+    const userId = client.handshake.auth.userId || client.id;
+    const updated = await this.notificationsService.markAsRead(payload.id, userId);
+    client.emit('notification-updated', updated);
+  }
+
+  /**
+   * Client emits 'mark-unread' with { id: string }
+   * Server responds with 'notification-updated' event.
+   */
+  @SubscribeMessage('mark-unread')
+  async handleMarkUnread(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: { id: string },
+  ) {
+    const userId = client.handshake.auth.userId || client.id;
+    const updated = await this.notificationsService.markAsUnread(payload.id, userId);
+    client.emit('notification-updated', updated);
+  }
+
+  /**
+   * Client emits 'mark-all-read'
+   * Server responds with 'notifications-all-read' event.
+   */
+  @SubscribeMessage('mark-all-read')
+  async handleMarkAllRead(@ConnectedSocket() client: Socket) {
+    const userId = client.handshake.auth.userId || client.id;
+    const result = await this.notificationsService.markAllAsRead(userId);
+    client.emit('notifications-all-read', result);
+  }
+
+  /**
+   * Client emits 'bulk-action' with BulkActionDto
+   * Server responds with 'bulk-action-result' event.
+   */
+  @SubscribeMessage('bulk-action')
+  async handleBulkAction(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: BulkActionDto,
+  ) {
+    const userId = client.handshake.auth.userId || client.id;
+    const result = await this.notificationsService.bulkAction(userId, dto);
+    client.emit('bulk-action-result', result);
+  }
+
+  // ── Push helpers (called by NotificationsService) ───────────────────────────
+
   async sendNotification(userId: string, notification: NotificationDto) {
     const sockets = this.connectionService.getActiveSocketsForUser(userId);
 
     if (sockets.length === 0) {
-      await this.messageQueueService.queueMessage(
-        userId,
-        'notification',
-        notification,
-      );
+      // User is offline — queue for delivery on next connection
+      await this.messageQueueService.queueMessage(userId, 'notification', notification);
       return;
     }
 

--- a/backend/src/websocket/websocket.module.ts
+++ b/backend/src/websocket/websocket.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -10,6 +10,7 @@ import { WebSocketRateLimitService } from './services/websocket-rate-limit.servi
 import { NotificationsGateway } from './gateways/notifications.gateway';
 import { LocationGateway } from './gateways/location.gateway';
 import { EmergencyGateway } from './gateways/emergency.gateway';
+import { NotificationsModule } from 'src/modules/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { EmergencyGateway } from './gateways/emergency.gateway';
       max: 10000,
     }),
     ScheduleModule.forRoot(),
+    forwardRef(() => NotificationsModule),
   ],
   providers: [
     WebSocketConnectionService,
@@ -36,4 +38,4 @@ import { EmergencyGateway } from './gateways/emergency.gateway';
     EmergencyGateway,
   ],
 })
-export class WebSocketModule {}
+export class WebSocketModule { }


### PR DESCRIPTION
## Description
Adds a complete in-app notification center to the platform. Users can receive, read, manage, and configure notifications in real time via WebSocket. The system hooks into the existing `NotificationsGateway` and `WebSocketModule` without breaking any existing WebSocket functionality.

---

## Related Issues
Closes #82 

---

## Changes Made
- [x] Add `Notification` entity — stores notification records with category, read state, actionUrl, and metadata
- [x] Add `NotificationSetting` entity — per-user, per-category opt-in/out with a master global switch
- [x] Add `NotificationsService` — create, read, mark read/unread, mark all read, bulk actions, delete, settings CRUD
- [x] Add `NotificationsController` — full REST API for all of the above
- [x] Add DTOs — `CreateNotificationDto`, `NotificationQueryDto` (filter + pagination), `BulkActionDto`, `UpdateNotificationSettingDto`
- [x] Update `NotificationsGateway` — add 5 new WebSocket event handlers (`get-notifications`, `mark-read`, `mark-unread`, `mark-all-read`, `bulk-action`); all existing handlers preserved
- [x] Real-time unread count pushed to client on every state change
- [x] Offline users handled via existing `MessageQueueService` — notifications queued and delivered on reconnect
- [x] Update `WebSocketModule` — imports `NotificationsModule` with `forwardRef` to resolve circular dependency
- [x] Register `NotificationsModule` in `AppModule`

---

## How to Test

### 1. Setup
Run migrations to create the 2 new tables:
```bash
npm run migration:run
```
Confirm these tables exist in your DB:
- `notifications`
- `notification_settings`

### 2. Create a Notification (REST)
```bash
curl -X POST http://localhost:3000/notifications \
  -H "Content-Type: application/json" \
  -d '{
    "userId": "<uuid>",
    "title": "Appointment Reminder",
    "message": "Your pet has an appointment tomorrow.",
    "category": "APPOINTMENT"
  }'
```
Expected: `201` response with the saved notification. If the user is connected via WebSocket, they receive a `notification` event immediately.

### 3. List Notifications (REST)
```bash
# All notifications
curl http://localhost:3000/notifications/<userId>

# Filter by category
curl http://localhost:3000/notifications/<userId>?category=APPOINTMENT

# Filter unread only
curl http://localhost:3000/notifications/<userId>?isRead=false

# Paginate
curl http://localhost:3000/notifications/<userId>?page=1&limit=10
```
Expected: `{ data: [...], total: N, unreadCount: N }`

### 4. Mark Read / Unread (REST)
```bash
# Mark single as read
curl -X PATCH http://localhost:3000/notifications/<userId>/<id>/read

# Mark single as unread
curl -X PATCH http://localhost:3000/notifications/<userId>/<id>/unread

# Mark all as read
curl -X PATCH http://localhost:3000/notifications/<userId>/read-all
```
Expected: updated notification returned. Connected WebSocket client receives a `notification` event with updated `unreadCount`.

### 5. Bulk Actions (REST)
```bash
# Mark multiple as read
curl -X PATCH http://localhost:3000/notifications/<userId>/bulk \
  -H "Content-Type: application/json" \
  -d '{"ids": ["<uuid1>", "<uuid2>"], "action": "MARK_READ"}'

# Delete multiple
curl -X PATCH http://localhost:3000/notifications/<userId>/bulk \
  -H "Content-Type: application/json" \
  -d '{"ids": ["<uuid1>", "<uuid2>"], "action": "DELETE"}'
```
Expected: `{ affected: N }`. IDs belonging to other users are silently ignored.

### 6. Notification Settings (REST)
```bash
# Get settings (creates defaults if none exist)
curl http://localhost:3000/notifications/<userId>/settings

# Disable appointment notifications
curl -X PATCH http://localhost:3000/notifications/<userId>/settings \
  -H "Content-Type: application/json" \
  -d '{"appointment": false}'
```
After disabling `appointment`, create an `APPOINTMENT` notification for that user — it should be skipped (not saved, not pushed).

### 7. Real-Time via WebSocket
Connect a Socket.IO client to `ws://localhost:3000/notifications` with `auth: { userId: "<uuid>" }`, then emit:
```js
// Fetch notifications
socket.emit('get-notifications', { page: 1, limit: 20 });
socket.on('notifications-list', (data) => console.log(data));

// Mark as read
socket.emit('mark-read', { id: '<uuid>' });
socket.on('notification-updated', (n) => console.log(n));

// Bulk action
socket.emit('bulk-action', { ids: ['<uuid>'], action: 'MARK_UNREAD' });
socket.on('bulk-action-result', (r) => console.log(r));
```

### 8. Offline Queue
Disconnect the WebSocket client, create a notification for that user via REST, then reconnect. Expected: the notification is delivered immediately on reconnect via the existing `MessageQueueService`.

---

## Screenshots (if applicable)
N/A — no UI changes.

---

## Checklist
- [x] My code follows the project's coding style.
- [ ] I have tested these changes locally.
- [x] Documentation has been updated where necessary.