### PR TITLE
feat: implement issues #334, #335, #336, #337

### DIFF
--- a/backend/src/modules/behavior/entities/behavior-log.entity.ts
+++ b/backend/src/modules/behavior/entities/behavior-log.entity.ts
@@ -1,0 +1,83 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Pet } from '../../pets/entities/pet.entity';
+
+/** Category of observed behavior */
+export enum BehaviorType {
+  AGGRESSION = 'aggression',
+  ANXIETY = 'anxiety',
+  APPETITE = 'appetite',
+  ENERGY_LEVEL = 'energy_level',
+  GROOMING = 'grooming',
+  PLAY = 'play',
+  SLEEP = 'sleep',
+  SOCIAL = 'social',
+  TRAINING = 'training',
+  OTHER = 'other',
+}
+
+/** Severity level of the logged behavior */
+export enum BehaviorSeverity {
+  MILD = 'mild',
+  MODERATE = 'moderate',
+  SEVERE = 'severe',
+}
+
+@Entity('behavior_logs')
+@Index(['petId', 'observedAt'])
+export class BehaviorLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', name: 'pet_id' })
+  @Index()
+  petId: string;
+
+  @ManyToOne(() => Pet, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'pet_id' })
+  pet: Pet;
+
+  @Column({
+    type: 'enum',
+    enum: BehaviorType,
+    name: 'behavior_type',
+  })
+  behaviorType: BehaviorType;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({
+    type: 'enum',
+    enum: BehaviorSeverity,
+    default: BehaviorSeverity.MILD,
+  })
+  severity: BehaviorSeverity;
+
+  @Column({ type: 'timestamptz', name: 'observed_at' })
+  @Index()
+  observedAt: Date;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string;
+
+  @Column({ nullable: true, name: 'recorded_by' })
+  recordedBy: string;
+
+  @Column({ default: false, name: 'requires_vet_attention' })
+  requiresVetAttention: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/wata-board-frontend/src/App.test.tsx
+++ b/wata-board-frontend/src/App.test.tsx
@@ -1,40 +1,190 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Contract Client', () => {
-  it('should have correct network configuration', async () => {
-    const { networks } = await import('../src/contracts');
-    
-    expect(networks.testnet).toBeDefined();
-    expect(networks.testnet.networkPassphrase).toBe('Test SDF Network ; September 2015');
-    expect(networks.testnet.contractId).toBe('CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA');
+// Mock heavy dependencies
+vi.mock('./utils/wallet-bridge', () => ({
+  isConnected: vi.fn().mockResolvedValue({ isConnected: false }),
+  requestAccess: vi.fn().mockResolvedValue({ address: null, error: 'Not connected' }),
+  signTransaction: vi.fn().mockResolvedValue({ signedTxXdr: '' }),
+}));
+
+vi.mock('@stellar/stellar-sdk', () => ({
+  Horizon: { Server: vi.fn() },
+  Networks: { TESTNET: 'Test SDF Network ; September 2015' },
+  TransactionBuilder: vi.fn(),
+  Operation: { payment: vi.fn() },
+  Asset: { native: vi.fn() },
+  BASE_FEE: '100',
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn(), language: 'en', dir: () => 'ltr' },
+  }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  I18nextProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('./utils/network-config', () => ({
+  getCurrentNetworkConfig: vi.fn().mockReturnValue({
+    networkPassphrase: 'Test SDF Network ; September 2015',
+    contractId: 'CDRRJ7IPYDL36YSK5ZQLBG3LICULETIBXX327AGJQNTWXNKY2UMDO4DA',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+  }),
+}));
+
+vi.mock('./utils/accessibility', () => ({
+  announceToScreenReader: vi.fn(),
+  generateId: vi.fn((prefix: string) => `${prefix}-test`),
+  setupKeyboardNavigation: vi.fn(),
+  setupFocusVisible: vi.fn(),
+}));
+
+vi.mock('./services/schedulingService', () => ({
+  SchedulingService: { getInstance: vi.fn().mockReturnValue({}) },
+}));
+
+vi.mock('./services/notificationService', () => ({
+  NotificationService: { getInstance: vi.fn().mockReturnValue({}) },
+}));
+
+vi.mock('./hooks/useWalletBalance', () => ({
+  useWalletBalance: vi.fn().mockReturnValue({
+    balance: null,
+    isSufficientBalance: vi.fn().mockReturnValue(true),
+    refreshBalance: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('./hooks/useFeeEstimation', () => ({
+  useFeeEstimation: vi.fn().mockReturnValue({
+    estimate: null,
+    estimateFee: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('./utils/offlineApi', () => ({
+  handleOfflineError: vi.fn(),
+  getOfflineErrorMessage: vi.fn().mockReturnValue('Offline'),
+}));
+
+vi.mock('./hooks/useConnectivity', () => ({
+  useConnectivity: vi.fn().mockReturnValue({ isOnline: true }),
+}));
+
+// Mock child components to isolate App rendering
+vi.mock('./components/ResponsiveNavigation', () => ({
+  ResponsiveNavigation: () => <nav data-testid="navigation" />,
+}));
+
+vi.mock('./components/SkipLinks', () => ({
+  SkipLinks: () => <div data-testid="skip-links" />,
+}));
+
+vi.mock('./components/OfflineBanner', () => ({
+  OfflineBanner: () => <div data-testid="offline-banner" />,
+}));
+
+vi.mock('./components/OfflineStatusIndicator', () => ({
+  OfflineStatusIndicator: () => <div data-testid="offline-status" />,
+}));
+
+vi.mock('./components/OfflineErrorBoundary', () => ({
+  OfflineErrorBoundary: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="error-boundary">{children}</div>
+  ),
+}));
+
+vi.mock('./components/WalletBalance', () => ({
+  WalletBalance: () => <div data-testid="wallet-balance" />,
+}));
+
+vi.mock('./pages/About', () => ({ default: () => <div data-testid="about-page" /> }));
+vi.mock('./pages/Contact', () => ({ default: () => <div data-testid="contact-page" /> }));
+vi.mock('./pages/Rate', () => ({ default: () => <div data-testid="rate-page" /> }));
+vi.mock('./pages/ScheduledPayments', () => ({
+  default: () => <div data-testid="scheduled-payments-page" />,
+}));
+
+import App from './App';
+
+describe('App component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    render(<App />);
+    expect(document.body).toBeTruthy();
+  });
+
+  it('renders navigation', () => {
+    render(<App />);
+    expect(screen.getByTestId('navigation')).toBeDefined();
+  });
+
+  it('renders skip links for accessibility', () => {
+    render(<App />);
+    expect(screen.getByTestId('skip-links')).toBeDefined();
+  });
+
+  it('renders error boundary wrapper', () => {
+    render(<App />);
+    expect(screen.getByTestId('error-boundary')).toBeDefined();
+  });
+
+  it('renders offline banner', () => {
+    render(<App />);
+    expect(screen.getByTestId('offline-banner')).toBeDefined();
   });
 });
 
-describe('Payment Validation', () => {
-  it('should validate positive amounts', () => {
-    const amount = 10;
-    expect(Number.isFinite(amount) && amount > 0).toBe(true);
+describe('App routing', () => {
+  it('renders home route by default', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(document.body).toBeTruthy();
   });
 
-  it('should reject negative amounts', () => {
-    const amount = -5;
-    expect(Number.isFinite(amount) && amount > 0).toBe(false);
+  it('renders about page on /about route', () => {
+    render(
+      <MemoryRouter initialEntries={['/about']}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('about-page')).toBeDefined();
   });
 
-  it('should reject zero amount', () => {
-    const amount = 0;
-    expect(Number.isFinite(amount) && amount > 0).toBe(false);
+  it('renders contact page on /contact route', () => {
+    render(
+      <MemoryRouter initialEntries={['/contact']}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('contact-page')).toBeDefined();
+  });
+
+  it('renders scheduled payments page on /scheduled-payments route', () => {
+    render(
+      <MemoryRouter initialEntries={['/scheduled-payments']}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('scheduled-payments-page')).toBeDefined();
   });
 });
 
-describe('Meter ID Validation', () => {
-  it('should accept valid meter IDs', () => {
-    const meterId = 'METER-001';
-    expect(meterId.trim().length > 0).toBe(true);
-  });
-
-  it('should reject empty meter IDs', () => {
-    const meterId = '   ';
-    expect(meterId.trim().length > 0).toBe(false);
+describe('App context providers', () => {
+  it('provides wallet balance context', () => {
+    render(<App />);
+    expect(screen.getByTestId('wallet-balance')).toBeDefined();
   });
 });

--- a/wata-board-frontend/src/contracts/src/helpers.ts
+++ b/wata-board-frontend/src/contracts/src/helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Helper functions for interacting with the NEPA smart contract.
+ */
+import { networks } from './index';
+import type { NetworkName, NetworkConfig, PayBillParams, GetTotalPaidParams } from './types';
+
+/**
+ * Returns the network configuration for the given network name.
+ */
+export function getNetworkConfig(network: NetworkName): NetworkConfig {
+  return networks[network];
+}
+
+/**
+ * Validates pay_bill parameters before submitting a transaction.
+ */
+export function validatePayBillParams(params: PayBillParams): void {
+  if (!params.meter_id || params.meter_id.trim().length === 0) {
+    throw new Error('meter_id must be a non-empty string');
+  }
+  if (!Number.isInteger(params.amount) || params.amount <= 0) {
+    throw new Error('amount must be a positive integer');
+  }
+  if (params.amount > 4_294_967_295) {
+    throw new Error('amount exceeds u32 maximum value');
+  }
+}
+
+/**
+ * Validates get_total_paid parameters.
+ */
+export function validateGetTotalPaidParams(params: GetTotalPaidParams): void {
+  if (!params.meter_id || params.meter_id.trim().length === 0) {
+    throw new Error('meter_id must be a non-empty string');
+  }
+}
+
+/**
+ * Returns true if the given string is a valid Stellar contract ID (56-char base32).
+ */
+export function isValidContractId(contractId: string): boolean {
+  return /^[A-Z2-7]{56}$/.test(contractId);
+}
+
+/**
+ * Returns the contract ID for the given network.
+ */
+export function getContractId(network: NetworkName): string {
+  return networks[network].contractId;
+}

--- a/wata-board-frontend/src/contracts/src/types.ts
+++ b/wata-board-frontend/src/contracts/src/types.ts
@@ -1,0 +1,51 @@
+/**
+ * TypeScript interfaces and types for the NEPA smart contract.
+ */
+
+/** Supported network names */
+export type NetworkName = 'testnet' | 'mainnet';
+
+/** Network configuration for a deployed contract */
+export interface NetworkConfig {
+  /** Stellar network passphrase */
+  networkPassphrase: string;
+  /** Deployed contract ID on this network */
+  contractId: string;
+  /** Soroban RPC endpoint URL */
+  rpcUrl: string;
+}
+
+/** Result of a pay_bill contract call */
+export interface PayBillResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+/** Result of a get_total_paid contract call */
+export interface GetTotalPaidResult {
+  meterId: string;
+  totalPaid: number;
+}
+
+/** Parameters for the pay_bill contract method */
+export interface PayBillParams {
+  /** Meter identifier */
+  meter_id: string;
+  /** Amount to pay (u32) */
+  amount: number;
+}
+
+/** Parameters for the get_total_paid contract method */
+export interface GetTotalPaidParams {
+  /** Meter identifier */
+  meter_id: string;
+}
+
+/** Deployment information for the contract */
+export interface DeploymentInfo {
+  network: NetworkName;
+  contractId: string;
+  deployedAt?: string;
+  wasmHash?: string;
+}

--- a/wata-board-frontend/src/types/scheduling.ts
+++ b/wata-board-frontend/src/types/scheduling.ts
@@ -1,42 +1,88 @@
-export enum PaymentFrequency {
+/**
+ * Scheduling types for payment scheduling functionality.
+ * Defines TypeScript types for creating, managing, and tracking recurring payment schedules.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/** Frequency options for a recurring schedule */
+export enum ScheduleFrequency {
   ONCE = 'once',
   DAILY = 'daily',
   WEEKLY = 'weekly',
   BIWEEKLY = 'biweekly',
   MONTHLY = 'monthly',
   QUARTERLY = 'quarterly',
-  YEARLY = 'yearly'
+  YEARLY = 'yearly',
 }
 
-export enum PaymentStatus {
+/** Lifecycle status of a schedule */
+export enum ScheduleStatus {
   PENDING = 'pending',
   SCHEDULED = 'scheduled',
   PROCESSING = 'processing',
   COMPLETED = 'completed',
   FAILED = 'failed',
   CANCELLED = 'cancelled',
-  PAUSED = 'paused'
+  PAUSED = 'paused',
 }
 
+/** Notification event types for a schedule */
 export enum NotificationType {
   PAYMENT_DUE = 'payment_due',
   PAYMENT_SUCCESS = 'payment_success',
   PAYMENT_FAILED = 'payment_failed',
   SCHEDULE_CREATED = 'schedule_created',
-  SCHEDULE_CANCELLED = 'schedule_cancelled'
+  SCHEDULE_CANCELLED = 'schedule_cancelled',
 }
 
-export interface PaymentSchedule {
+// ---------------------------------------------------------------------------
+// Core interfaces
+// ---------------------------------------------------------------------------
+
+/** Notification preferences attached to a schedule */
+export interface NotificationSettings {
+  email: boolean;
+  push: boolean;
+  sms: boolean;
+  /** Days before payment to send a reminder (e.g. [1, 3, 7]) */
+  reminderDays: number[];
+  successNotification: boolean;
+  failureNotification: boolean;
+}
+
+/** A single scheduled payment execution record */
+export interface ScheduledPayment {
+  id: string;
+  scheduleId: string;
+  amount: number;
+  scheduledDate: Date;
+  actualPaymentDate?: Date;
+  status: ScheduleStatus;
+  transactionId?: string;
+  errorMessage?: string;
+  retryCount: number;
+  createdAt: Date;
+}
+
+/**
+ * Core schedule entity representing a payment schedule.
+ * Tracks all metadata required to execute and monitor recurring payments.
+ */
+export interface Schedule {
   id: string;
   userId: string;
   meterId: string;
   amount: number;
-  frequency: PaymentFrequency;
+  frequency: ScheduleFrequency;
   startDate: Date;
   endDate?: Date;
   nextPaymentDate: Date;
-  status: PaymentStatus;
+  status: ScheduleStatus;
   description?: string;
+  /** Maximum number of payments before the schedule auto-completes */
   maxPayments?: number;
   currentPaymentCount: number;
   createdAt: Date;
@@ -45,32 +91,25 @@ export interface PaymentSchedule {
   paymentHistory: ScheduledPayment[];
 }
 
-export interface ScheduledPayment {
-  id: string;
-  scheduleId: string;
-  amount: number;
-  scheduledDate: Date;
-  actualPaymentDate?: Date;
-  status: PaymentStatus;
-  transactionId?: string;
-  errorMessage?: string;
-  retryCount: number;
-  createdAt: Date;
-}
+/**
+ * A recurring schedule extends Schedule with recurrence-specific fields.
+ * Use this type when the schedule is guaranteed to repeat more than once.
+ */
+export type RecurringSchedule = Schedule & {
+  frequency: Exclude<ScheduleFrequency, ScheduleFrequency.ONCE>;
+  /** ISO 8601 recurrence rule string (e.g. "FREQ=MONTHLY;INTERVAL=1") */
+  rrule?: string;
+};
 
-export interface NotificationSettings {
-  email: boolean;
-  push: boolean;
-  sms: boolean;
-  reminderDays: number[];
-  successNotification: boolean;
-  failureNotification: boolean;
-}
+// ---------------------------------------------------------------------------
+// Form & validation types
+// ---------------------------------------------------------------------------
 
+/** Raw form data before parsing into a Schedule */
 export interface ScheduleFormData {
   meterId: string;
   amount: string;
-  frequency: PaymentFrequency;
+  frequency: ScheduleFrequency;
   startDate: string;
   endDate?: string;
   description?: string;
@@ -78,15 +117,24 @@ export interface ScheduleFormData {
   notificationSettings: NotificationSettings;
 }
 
-export interface ScheduleTemplate {
-  id: string;
-  name: string;
-  description: string;
-  frequency: PaymentFrequency;
-  suggestedAmount?: number;
-  commonUseCases: string[];
+/** A single validation error on a schedule form field */
+export interface ScheduleValidationError {
+  field: string;
+  message: string;
 }
 
+/** Result of validating schedule form data */
+export interface ScheduleValidationResult {
+  isValid: boolean;
+  errors: ScheduleValidationError[];
+  warnings: ScheduleValidationError[];
+}
+
+// ---------------------------------------------------------------------------
+// Analytics & projection types
+// ---------------------------------------------------------------------------
+
+/** Aggregated analytics for a user's schedules */
 export interface PaymentAnalytics {
   totalScheduled: number;
   totalCompleted: number;
@@ -98,26 +146,7 @@ export interface PaymentAnalytics {
   monthlyProjection: number;
 }
 
-export interface CalendarEvent {
-  date: Date;
-  payments: ScheduledPayment[];
-  totalAmount: number;
-  status: 'upcoming' | 'completed' | 'failed';
-}
-
-// Validation types
-export interface ScheduleValidationError {
-  field: string;
-  message: string;
-}
-
-export interface ScheduleValidationResult {
-  isValid: boolean;
-  errors: ScheduleValidationError[];
-  warnings: ScheduleValidationError[];
-}
-
-// Helper types for calculations
+/** Payment amount projections derived from a schedule */
 export interface PaymentCalculation {
   nextPaymentDate: Date;
   paymentCount: number;
@@ -130,34 +159,19 @@ export interface PaymentCalculation {
   };
 }
 
-// API Response types
-export interface CreateScheduleResponse {
-  success: boolean;
-  schedule?: PaymentSchedule;
-  error?: string;
+// ---------------------------------------------------------------------------
+// Calendar types
+// ---------------------------------------------------------------------------
+
+/** A calendar day entry grouping payments by date */
+export interface CalendarEvent {
+  date: Date;
+  payments: ScheduledPayment[];
+  totalAmount: number;
+  status: 'upcoming' | 'completed' | 'failed';
 }
 
-export interface UpdateScheduleResponse {
-  success: boolean;
-  schedule?: PaymentSchedule;
-  error?: string;
-}
-
-export interface GetSchedulesResponse {
-  success: boolean;
-  schedules?: PaymentSchedule[];
-  analytics?: PaymentAnalytics;
-  error?: string;
-}
-
-export interface CancelScheduleResponse {
-  success: boolean;
-  cancelledPayments?: number;
-  refundAmount?: number;
-  error?: string;
-}
-
-// Calendar view types
+/** Calendar view state */
 export interface CalendarView {
   month: Date;
   events: CalendarEvent[];
@@ -165,17 +179,45 @@ export interface CalendarView {
   viewMode: 'month' | 'week' | 'day';
 }
 
-// Recurrence calculation types
-export interface RecurrenceRule {
-  frequency: PaymentFrequency;
-  interval: number;
-  count?: number;
-  until?: Date;
-  byWeekDay?: number[];
-  byMonthDay?: number[];
+// ---------------------------------------------------------------------------
+// API response types
+// ---------------------------------------------------------------------------
+
+/** Response from creating a new schedule */
+export interface CreateScheduleResponse {
+  success: boolean;
+  schedule?: Schedule;
+  error?: string;
 }
 
-// Notification payload types
+/** Response from updating an existing schedule */
+export interface UpdateScheduleResponse {
+  success: boolean;
+  schedule?: Schedule;
+  error?: string;
+}
+
+/** Response from fetching schedules */
+export interface GetSchedulesResponse {
+  success: boolean;
+  schedules?: Schedule[];
+  analytics?: PaymentAnalytics;
+  error?: string;
+}
+
+/** Response from cancelling a schedule */
+export interface CancelScheduleResponse {
+  success: boolean;
+  cancelledPayments?: number;
+  refundAmount?: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Notification types
+// ---------------------------------------------------------------------------
+
+/** Notification payload sent when a schedule event occurs */
 export interface PaymentNotification {
   type: NotificationType;
   scheduleId: string;
@@ -187,7 +229,21 @@ export interface PaymentNotification {
   actionUrl?: string;
 }
 
-// Export utility types
+// ---------------------------------------------------------------------------
+// Export / template types
+// ---------------------------------------------------------------------------
+
+/** A reusable schedule template */
+export interface ScheduleTemplate {
+  id: string;
+  name: string;
+  description: string;
+  frequency: ScheduleFrequency;
+  suggestedAmount?: number;
+  commonUseCases: string[];
+}
+
+/** Parameters for exporting schedule data */
 export interface ScheduleExport {
   format: 'csv' | 'json' | 'pdf';
   dateRange: {
@@ -197,3 +253,30 @@ export interface ScheduleExport {
   includeHistory: boolean;
   includeAnalytics: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Recurrence rule type
+// ---------------------------------------------------------------------------
+
+/** Low-level recurrence rule for computing future payment dates */
+export interface RecurrenceRule {
+  frequency: ScheduleFrequency;
+  interval: number;
+  count?: number;
+  until?: Date;
+  byWeekDay?: number[];
+  byMonthDay?: number[];
+}
+
+// ---------------------------------------------------------------------------
+// Legacy aliases (backward compatibility)
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use {@link ScheduleFrequency} instead */
+export { ScheduleFrequency as PaymentFrequency };
+
+/** @deprecated Use {@link ScheduleStatus} instead */
+export { ScheduleStatus as PaymentStatus };
+
+/** @deprecated Use {@link Schedule} instead */
+export type PaymentSchedule = Schedule;


### PR DESCRIPTION
## Summary

Resolves #334, #335, #336, #337
closes #334 
closes #335 
closes #336 
closes #337

### Changes

**#334 – App Test**
- Reimplemented `wata-board-frontend/src/App.test.tsx` with Vitest
- Tests cover: component rendering, routing (home/about/contact/scheduled-payments), context providers, error boundary, accessibility (skip links)
- All heavy dependencies mocked (wallet-bridge, stellar-sdk, i18next, services)

**#335 – Contracts Package**
- Added `wata-board-frontend/src/contracts/src/types.ts`: TypeScript interfaces for `NetworkConfig`, `PayBillParams`, `GetTotalPaidParams`, `DeploymentInfo`, etc.
- Added `wata-board-frontend/src/contracts/src/helpers.ts`: helper functions for network config lookup, parameter validation, and contract ID validation

**#336 – Scheduling Types**
- Reimplemented `wata-board-frontend/src/types/scheduling.ts`
- Exports: `ScheduleFrequency` enum, `ScheduleStatus` enum, `Schedule` interface, `RecurringSchedule` type, plus form, analytics, calendar, API response, and notification types
- Backward-compatible aliases for `PaymentFrequency`, `PaymentStatus`, `PaymentSchedule`

**#337 – Behavior Log Entity**
- Created `backend/src/modules/behavior/entities/behavior-log.entity.ts`
- TypeORM entity with `BehaviorType` enum, `BehaviorSeverity` enum, `Pet` ManyToOne relationship, composite index on `(petId, observedAt)`, timestamps

### Testing
No test runner executed per task instructions.