### PR TITLE
Restore default English localization file for wata-board-frontend

### DIFF
--- a/wata-board-frontend/src/i18n/locales/en.json
+++ b/wata-board-frontend/src/i18n/locales/en.json
@@ -38,9 +38,11 @@
       "amountTooLarge": "Amount is too large.",
       "insufficientBalance": "Insufficient balance. Please add more XLM to your wallet.",
       "estimatingFees": "Estimating transaction fees... Please wait.",
+      "estimationFailed": "Unable to estimate transaction fees. Please try again.",
       "paymentSuccess": "Payment successful! Transaction ID: {{id}}...",
       "paymentFailed": "Payment failed: {{error}}"
     },
+
     "feeEstimation": {
       "title": "Transaction Fee Estimation",
       "calculating": "(Calculating...)",


### PR DESCRIPTION
this PR closes #371