### PR TITLE
feat: add Portuguese (pt-BR) localization

### DIFF
--- a/wata-board-frontend/src/i18n/locales/pt.json
+++ b/wata-board-frontend/src/i18n/locales/pt.json
@@ -1,243 +1,246 @@
 {
   "app": {
     "title": "Wata-Board",
-    "tagline": "Decentralized utility payments on Stellar blockchain",
-    "description": "Pay your utility bills using cryptocurrency on the Stellar network"
+    "tagline": "Pagamentos de serviços descentralizados na blockchain Stellar",
+    "description": "Pague suas contas de serviços usando criptomoeda na rede Stellar",
+    "footer": {
+      "tagline": "Soluções de pagamento modernas para a web descentralizada"
+    }
   },
   "navigation": {
-    "home": "Pay Bill",
-    "about": "About",
-    "contact": "Contact",
-    "rate": "Rate Us",
-    "language": "Language"
+    "home": "Pagar Conta",
+    "about": "Sobre",
+    "contact": "Contato",
+    "rate": "Avalie-nos",
+    "language": "Idioma"
   },
   "payment": {
     "form": {
-      "title": "Payment Information",
-      "meterNumber": "Meter number",
-      "meterPlaceholder": "e.g. METER-123",
-      "meterDescription": "Enter your utility meter number as shown on your bill",
-      "amount": "Amount",
-      "amountPlaceholder": "Whole number",
-      "amountDescription": "Enter the payment amount in whole XLM",
-      "payButton": "Pay bill",
-      "processing": "Processing...",
-      "rateLimited": "Rate Limited",
-      "requiresExtension": "Requires Freighter extension. 5 transactions per minute limit."
+      "title": "Informações de Pagamento",
+      "meterNumber": "Número do medidor",
+      "meterPlaceholder": "ex.: MEDIDOR-123",
+      "meterDescription": "Insira o número do medidor conforme exibido na sua conta",
+      "amount": "Valor",
+      "amountPlaceholder": "Número inteiro",
+      "amountDescription": "Insira o valor do pagamento em XLM inteiro",
+      "payButton": "Pagar conta",
+      "processing": "Processando...",
+      "rateLimited": "Limite de requisições atingido",
+      "requiresExtension": "Requer a extensão Freighter. Limite de 5 transações por minuto."
     },
     "status": {
       "title": "Status",
-      "ready": "Ready.",
-      "installWallet": "Please install Freighter Wallet extension!",
-      "enterMeter": "Please enter a meter number.",
-      "enterValidAmount": "Please enter a valid amount greater than 0.",
-      "wholeNumber": "Amount must be a whole number.",
-      "amountTooLarge": "Amount is too large.",
-      "insufficientBalance": "Insufficient balance. Please add more XLM to your wallet.",
-      "estimatingFees": "Estimating transaction fees... Please wait.",
-      "paymentSuccess": "Payment successful! Transaction ID: {{id}}...",
-      "paymentFailed": "Payment failed: {{error}}"
+      "ready": "Pronto.",
+      "installWallet": "Por favor, instale a extensão Freighter Wallet!",
+      "enterMeter": "Por favor, insira um número de medidor.",
+      "enterValidAmount": "Por favor, insira um valor válido maior que 0.",
+      "wholeNumber": "O valor deve ser um número inteiro.",
+      "amountTooLarge": "O valor é muito grande.",
+      "insufficientBalance": "Saldo insuficiente. Por favor, adicione mais XLM à sua carteira.",
+      "estimatingFees": "Estimando taxas de transação... Por favor, aguarde.",
+      "paymentSuccess": "Pagamento realizado com sucesso! ID da transação: {{id}}...",
+      "paymentFailed": "Falha no pagamento: {{error}}"
     },
     "feeEstimation": {
-      "title": "Transaction Fee Estimation",
-      "calculating": "(Calculating...)",
-      "calculatingFees": "Calculating estimated fees...",
-      "paymentAmount": "Payment Amount",
-      "estimatedNetworkFee": "Estimated Network Fee",
-      "totalCost": "Total Cost",
-      "unableToEstimate": "Unable to estimate fees at this time"
+      "title": "Estimativa de Taxa de Transação",
+      "calculating": "(Calculando...)",
+      "calculatingFees": "Calculando taxas estimadas...",
+      "paymentAmount": "Valor do Pagamento",
+      "estimatedNetworkFee": "Taxa de Rede Estimada",
+      "totalCost": "Custo Total",
+      "unableToEstimate": "Não foi possível estimar as taxas no momento"
     },
     "rateLimit": {
-      "title": "Rate Limit Status",
-      "requestsAvailable": "{{count}}/5 requests available",
-      "rateLimited": "Rate limited. Reset in {{time}}",
-      "queue": "Queue: {{count}}"
+      "title": "Status do Limite de Requisições",
+      "requestsAvailable": "{{count}}/5 requisições disponíveis",
+      "rateLimited": "Limite atingido. Reinicia em {{time}}",
+      "queue": "Fila: {{count}}"
     }
   },
   "wallet": {
     "balance": {
-      "title": "Wallet Balance",
-      "available": "Available Balance",
-      "total": "Total Balance",
-      "loading": "Loading balance...",
-      "error": "Failed to load balance",
-      "reconnect": "Please reconnect your wallet",
-      "insufficient": "Insufficient balance for this transaction",
-      "lowBalance": "Low balance warning"
+      "title": "Saldo da Carteira",
+      "available": "Saldo Disponível",
+      "total": "Saldo Total",
+      "loading": "Carregando saldo...",
+      "error": "Falha ao carregar saldo",
+      "reconnect": "Por favor, reconecte sua carteira",
+      "insufficient": "Saldo insuficiente para esta transação",
+      "lowBalance": "Aviso de saldo baixo"
     },
     "connection": {
-      "connected": "Connected",
-      "disconnected": "Disconnected",
-      "connecting": "Connecting...",
-      "connectWallet": "Connect Wallet",
-      "switchWallet": "Switch Wallet"
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "connecting": "Conectando...",
+      "connectWallet": "Conectar Carteira",
+      "switchWallet": "Trocar Carteira"
     }
   },
   "network": {
-    "mainnet": "MAINNET",
-    "testnet": "TESTNET",
-    "switchNetwork": "Switch Network",
-    "currentNetwork": "Current Network"
+    "mainnet": "REDE PRINCIPAL",
+    "testnet": "REDE DE TESTE",
+    "switchNetwork": "Trocar Rede",
+    "currentNetwork": "Rede Atual"
   },
   "offline": {
     "banner": {
-      "title": "You're offline",
-      "description": "Some features may be unavailable. Actions will be queued and processed when you're back online.",
-      "retry": "Retry Connection",
-      "details": "Connection Details"
+      "title": "Você está offline",
+      "description": "Alguns recursos podem estar indisponíveis. As ações serão enfileiradas e processadas quando você voltar online.",
+      "retry": "Tentar Reconectar",
+      "details": "Detalhes da Conexão"
     },
     "status": {
       "online": "Online",
       "offline": "Offline",
-      "connecting": "Connecting...",
-      "queueStatus": "{{count}} queued action",
-      "queueStatus_plural": "{{count}} queued actions"
+      "connecting": "Conectando...",
+      "queueStatus": "{{count}} ação na fila",
+      "queueStatus_plural": "{{count}} ações na fila"
     },
     "queue": {
-      "title": "Offline Queue",
-      "description": "{{count}} action will be processed when you're back online",
-      "description_plural": "{{count}} actions will be processed when you're back online"
+      "title": "Fila Offline",
+      "description": "{{count}} ação será processada quando você voltar online",
+      "description_plural": "{{count}} ações serão processadas quando você voltar online"
     },
     "error": {
-      "paymentOffline": "Payment queued for when you're back online",
-      "generalOffline": "Action queued for when you're back online"
+      "paymentOffline": "Pagamento enfileirado para quando você voltar online",
+      "generalOffline": "Ação enfileirada para quando você voltar online"
     }
   },
   "about": {
-    "title": "About Wata-Board",
-    "description": "Wata-Board is a decentralized utility payment platform built on the Stellar blockchain. We enable secure, transparent, and efficient utility bill payments using cryptocurrency.",
+    "title": "Sobre o Wata-Board",
+    "description": "O Wata-Board é uma plataforma descentralizada de pagamento de serviços construída na blockchain Stellar. Permitimos pagamentos de contas de serviços de forma segura, transparente e eficiente usando criptomoeda.",
     "features": {
-      "title": "Key Features",
-      "secure": "Secure Transactions",
-      "secureDescription": "Built on Stellar blockchain with enterprise-grade security",
-      "fast": "Fast Payments",
-      "fastDescription": "Near-instant settlement with low transaction fees",
-      "transparent": "Transparent Records",
-      "transparentDescription": "All transactions are recorded on the public blockchain",
-      "decentralized": "Decentralized",
-      "decentralizedDescription": "No single point of failure or control"
+      "title": "Principais Recursos",
+      "secure": "Transações Seguras",
+      "secureDescription": "Construído na blockchain Stellar com segurança de nível empresarial",
+      "fast": "Pagamentos Rápidos",
+      "fastDescription": "Liquidação quase instantânea com baixas taxas de transação",
+      "transparent": "Registros Transparentes",
+      "transparentDescription": "Todas as transações são registradas na blockchain pública",
+      "decentralized": "Descentralizado",
+      "decentralizedDescription": "Sem ponto único de falha ou controle"
     },
     "howItWorks": {
-      "title": "How It Works",
-      "step1": "Connect your wallet",
-      "step2": "Enter meter details",
-      "step3": "Confirm payment",
-      "step4": "Payment processed"
+      "title": "Como Funciona",
+      "step1": "Conecte sua carteira",
+      "step2": "Insira os dados do medidor",
+      "step3": "Confirme o pagamento",
+      "step4": "Pagamento processado"
     }
   },
   "contact": {
-    "title": "Contact Us",
-    "description": "Get in touch with our team for support, questions, or feedback.",
+    "title": "Fale Conosco",
+    "description": "Entre em contato com nossa equipe para suporte, dúvidas ou feedback.",
     "form": {
-      "name": "Name",
-      "namePlaceholder": "Enter your name",
-      "email": "Email",
-      "emailPlaceholder": "Enter your email",
-      "subject": "Subject",
-      "subjectPlaceholder": "Enter subject",
-      "message": "Message",
-      "messagePlaceholder": "Enter your message",
-      "sendButton": "Send Message",
-      "sending": "Sending..."
+      "name": "Nome",
+      "namePlaceholder": "Digite seu nome",
+      "email": "E-mail",
+      "emailPlaceholder": "Digite seu e-mail",
+      "subject": "Assunto",
+      "subjectPlaceholder": "Digite o assunto",
+      "message": "Mensagem",
+      "messagePlaceholder": "Digite sua mensagem",
+      "sendButton": "Enviar Mensagem",
+      "sending": "Enviando..."
     },
     "info": {
-      "email": "Email",
-      "support": "Support",
-      "website": "Website"
+      "email": "E-mail",
+      "support": "Suporte",
+      "website": "Site"
     }
   },
   "rate": {
-    "title": "Rate Your Experience",
-    "description": "Help us improve by rating your experience with Wata-Board.",
+    "title": "Avalie sua Experiência",
+    "description": "Ajude-nos a melhorar avaliando sua experiência com o Wata-Board.",
     "rating": {
-      "excellent": "Excellent",
-      "good": "Good",
-      "average": "Average",
-      "poor": "Poor",
-      "terrible": "Terrible"
+      "excellent": "Excelente",
+      "good": "Bom",
+      "average": "Regular",
+      "poor": "Ruim",
+      "terrible": "Péssimo"
     },
     "review": {
-      "title": "Write a Review",
-      "placeholder": "Share your experience with Wata-Board...",
-      "submit": "Submit Review",
-      "thankYou": "Thank you for your feedback!"
+      "title": "Escreva uma Avaliação",
+      "placeholder": "Compartilhe sua experiência com o Wata-Board...",
+      "submit": "Enviar Avaliação",
+      "thankYou": "Obrigado pelo seu feedback!"
     }
   },
   "errors": {
     "general": {
-      "title": "Error",
-      "unknown": "An unknown error occurred",
-      "tryAgain": "Please try again",
-      "contactSupport": "Contact support if the problem persists"
+      "title": "Erro",
+      "unknown": "Ocorreu um erro desconhecido",
+      "tryAgain": "Por favor, tente novamente",
+      "contactSupport": "Entre em contato com o suporte se o problema persistir"
     },
     "network": {
-      "title": "Network Error",
-      "description": "Unable to connect to the network",
-      "checkConnection": "Please check your internet connection"
+      "title": "Erro de Rede",
+      "description": "Não foi possível conectar à rede",
+      "checkConnection": "Por favor, verifique sua conexão com a internet"
     },
     "wallet": {
-      "title": "Wallet Error",
-      "notConnected": "Wallet not connected",
-      "notInstalled": "Freighter wallet not installed",
-      "installFreighter": "Please install Freighter wallet extension"
+      "title": "Erro de Carteira",
+      "notConnected": "Carteira não conectada",
+      "notInstalled": "Carteira Freighter não instalada",
+      "installFreighter": "Por favor, instale a extensão da carteira Freighter"
     }
   },
   "accessibility": {
-    "skipToMain": "Skip to main content",
-    "skipToNavigation": "Skip to navigation",
-    "menuToggle": "Toggle navigation menu",
-    "closeMenu": "Close menu",
-    "openMenu": "Open menu",
-    "loading": "Loading...",
-    "error": "Error",
-    "success": "Success",
-    "warning": "Warning",
-    "info": "Information"
+    "skipToMain": "Ir para o conteúdo principal",
+    "skipToNavigation": "Ir para a navegação",
+    "menuToggle": "Alternar menu de navegação",
+    "closeMenu": "Fechar menu",
+    "openMenu": "Abrir menu",
+    "loading": "Carregando...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "warning": "Aviso",
+    "info": "Informação"
   },
   "common": {
-    "cancel": "Cancel",
-    "confirm": "Confirm",
-    "save": "Save",
-    "delete": "Delete",
-    "edit": "Edit",
-    "close": "Close",
-    "back": "Back",
-    "next": "Next",
-    "previous": "Previous",
-    "submit": "Submit",
-    "reset": "Reset",
-    "clear": "Clear",
-    "search": "Search",
-    "filter": "Filter",
-    "sort": "Sort",
-    "loading": "Loading...",
-    "error": "Error",
-    "success": "Success",
-    "retry": "Retry",
-    "refresh": "Refresh",
-    "copy": "Copy",
-    "copied": "Copied!",
-    "learnMore": "Learn More",
-    "viewDetails": "View Details",
-    "hideDetails": "Hide Details"
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "previous": "Anterior",
+    "submit": "Enviar",
+    "reset": "Redefinir",
+    "clear": "Limpar",
+    "search": "Pesquisar",
+    "filter": "Filtrar",
+    "sort": "Ordenar",
+    "loading": "Carregando...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "retry": "Tentar novamente",
+    "refresh": "Atualizar",
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "learnMore": "Saiba Mais",
+    "viewDetails": "Ver Detalhes",
+    "hideDetails": "Ocultar Detalhes"
   },
   "time": {
-    "seconds": "second",
-    "seconds_plural": "seconds",
-    "minutes": "minute",
-    "minutes_plural": "minutes",
-    "hours": "hour",
-    "hours_plural": "hours",
-    "days": "day",
-    "days_plural": "days",
-    "weeks": "week",
-    "weeks_plural": "weeks",
-    "months": "month",
-    "months_plural": "months",
-    "years": "year",
-    "years_plural": "years",
-    "ago": "{{time}} ago",
-    "in": "in {{time}}"
+    "seconds": "segundo",
+    "seconds_plural": "segundos",
+    "minutes": "minuto",
+    "minutes_plural": "minutos",
+    "hours": "hora",
+    "hours_plural": "horas",
+    "days": "dia",
+    "days_plural": "dias",
+    "weeks": "semana",
+    "weeks_plural": "semanas",
+    "months": "mês",
+    "months_plural": "meses",
+    "years": "ano",
+    "years_plural": "anos",
+    "ago": "há {{time}}",
+    "in": "em {{time}}"
   },
   "currency": {
     "xlm": "XLM",
@@ -245,13 +248,13 @@
     "eur": "EUR"
   },
   "validation": {
-    "required": "This field is required",
-    "invalid": "Invalid format",
-    "tooShort": "Must be at least {{min}} characters",
-    "tooLong": "Must be no more than {{max}} characters",
-    "invalidEmail": "Please enter a valid email address",
-    "invalidNumber": "Please enter a valid number",
-    "minValue": "Must be at least {{min}}",
-    "maxValue": "Must be no more than {{max}}"
+    "required": "Este campo é obrigatório",
+    "invalid": "Formato inválido",
+    "tooShort": "Deve ter pelo menos {{min}} caracteres",
+    "tooLong": "Deve ter no máximo {{max}} caracteres",
+    "invalidEmail": "Por favor, insira um endereço de e-mail válido",
+    "invalidNumber": "Por favor, insira um número válido",
+    "minValue": "Deve ser pelo menos {{min}}",
+    "maxValue": "Deve ser no máximo {{max}}"
   }
 }


### PR DESCRIPTION
Closes #366 

Issue: Re-implement the deleted Portuguese localization file for wata-board-frontend.
 
  What was done:
 
  1. Created branch feat/portuguese-localization off main
  2. Rewrote wata-board-frontend/src/i18n/locales/pt.json — the file existed but was an
  untranslated copy of en.json. Replaced all strings with accurate Brazilian Portuguese (pt-BR)    
  translations, including:
    - Added the missing app.footer.tagline key
    - Correct Portuguese pluralization for all _plural keys (e.g. mês/meses, segundo/segundos)     
    - Natural pt-BR phrasing throughout (payments, wallet, errors, accessibility, validation, etc.)

