### PR TITLE
Reintroduce Node tooling tsconfig

### DIFF
--- a/wata-board-frontend/package.json
+++ b/wata-board-frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck:node": "tsc -p tsconfig.node.json",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "playwright test"

--- a/wata-board-frontend/tsconfig.node.json
+++ b/wata-board-frontend/tsconfig.node.json
@@ -1,18 +1,21 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
-    "lib": ["ES2023"],
-    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": ["node"],
     "skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    /* Node tooling */
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
-    "noEmit": true,
 
     /* Linting */
     "strict": true,
@@ -22,5 +25,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "scripts/**/*.ts"],
+  "exclude": ["src", "dist", "node_modules"]
 }

--- a/wata-board-frontend/vite.config.ts
+++ b/wata-board-frontend/vite.config.ts
@@ -59,10 +59,29 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         output: {
           // Chunk splitting for optimal caching
-          manualChunks: {
-            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-            'vendor-stellar': ['@stellar/stellar-sdk', '@stellar/freighter-api'],
-            'vendor-i18n': ['i18next', 'react-i18next', 'i18next-browser-languagedetector'],
+          manualChunks: (moduleId) => {
+            if (!moduleId.includes('node_modules')) return undefined;
+            if (
+              moduleId.includes('react') ||
+              moduleId.includes('react-dom') ||
+              moduleId.includes('react-router-dom')
+            ) {
+              return 'vendor-react';
+            }
+            if (
+              moduleId.includes('@stellar/stellar-sdk') ||
+              moduleId.includes('@stellar/freighter-api')
+            ) {
+              return 'vendor-stellar';
+            }
+            if (
+              moduleId.includes('i18next') ||
+              moduleId.includes('react-i18next') ||
+              moduleId.includes('i18next-browser-languagedetector')
+            ) {
+              return 'vendor-i18n';
+            }
+            return undefined;
           },
         },
       },


### PR DESCRIPTION
Closes #358

---

# PR Description

## Summary
- restore node-specific TypeScript config for tooling and scripts
- add a node-only typecheck script
- update Vite rollup manualChunks to the Vite 8/rolldown function form
- fix fee estimation service merge artifact that broke typecheck

## Why
Node tooling (Vite config and other scripts) needs its own TS config and Node types, without clashing with browser app TS settings.

## Changes
- add [wata-board-frontend/tsconfig.node.json](wata-board-frontend/tsconfig.node.json) with NodeNext module settings, ES2022 target/lib, and tooling includes
- add `typecheck:node` script in [wata-board-frontend/package.json](wata-board-frontend/package.json)
- update manual chunking in [wata-board-frontend/vite.config.ts](wata-board-frontend/vite.config.ts)

## Testing
- `npm run typecheck:node`

## Notes
Full `npm run build` currently fails due to existing app/test issues outside the node tooling scope.
