### PR TITLE
feat(i18n): reimplement Hindi (hi) localization file

### DIFF
--- a/wata-board-frontend/src/i18n/locales/hi.json
+++ b/wata-board-frontend/src/i18n/locales/hi.json
@@ -1,243 +1,253 @@
 {
   "app": {
     "title": "Wata-Board",
-    "tagline": "Decentralized utility payments on Stellar blockchain",
-    "description": "Pay your utility bills using cryptocurrency on the Stellar network"
+    "tagline": "Stellar ब्लॉकचेन पर विकेंद्रीकृत उपयोगिता भुगतान",
+    "description": "Stellar नेटवर्क पर क्रिप्टोकरेंसी का उपयोग करके अपने उपयोगिता बिल का भुगतान करें",
+    "footer": {
+      "tagline": "विकेंद्रीकृत वेब के लिए आधुनिक भुगतान समाधान"
+    }
   },
   "navigation": {
-    "home": "Pay Bill",
-    "about": "About",
-    "contact": "Contact",
-    "rate": "Rate Us",
-    "language": "Language"
+    "home": "बिल चुकाएं",
+    "about": "हमारे बारे में",
+    "contact": "संपर्क",
+    "rate": "रेटिंग दें",
+    "language": "भाषा"
   },
   "payment": {
     "form": {
-      "title": "Payment Information",
-      "meterNumber": "Meter number",
-      "meterPlaceholder": "e.g. METER-123",
-      "meterDescription": "Enter your utility meter number as shown on your bill",
-      "amount": "Amount",
-      "amountPlaceholder": "Whole number",
-      "amountDescription": "Enter the payment amount in whole XLM",
-      "payButton": "Pay bill",
-      "processing": "Processing...",
-      "rateLimited": "Rate Limited",
-      "requiresExtension": "Requires Freighter extension. 5 transactions per minute limit."
+      "title": "भुगतान जानकारी",
+      "meterNumber": "मीटर नंबर",
+      "meterPlaceholder": "उदा. METER-123",
+      "meterDescription": "अपने बिल पर दिखाया गया उपयोगिता मीटर नंबर दर्ज करें",
+      "amount": "राशि",
+      "amountPlaceholder": "पूर्ण संख्या",
+      "amountDescription": "पूर्ण XLM में भुगतान राशि दर्ज करें",
+      "payButton": "बिल चुकाएं",
+      "processing": "प्रक्रिया हो रही है...",
+      "rateLimited": "सीमा पार हो गई",
+      "requiresExtension": "Freighter एक्सटेंशन आवश्यक है। प्रति मिनट 5 लेनदेन की सीमा।"
     },
     "status": {
-      "title": "Status",
-      "ready": "Ready.",
-      "installWallet": "Please install Freighter Wallet extension!",
-      "enterMeter": "Please enter a meter number.",
-      "enterValidAmount": "Please enter a valid amount greater than 0.",
-      "wholeNumber": "Amount must be a whole number.",
-      "amountTooLarge": "Amount is too large.",
-      "insufficientBalance": "Insufficient balance. Please add more XLM to your wallet.",
-      "estimatingFees": "Estimating transaction fees... Please wait.",
-      "paymentSuccess": "Payment successful! Transaction ID: {{id}}...",
-      "paymentFailed": "Payment failed: {{error}}"
+      "title": "स्थिति",
+      "ready": "तैयार।",
+      "installWallet": "कृपया Freighter Wallet एक्सटेंशन इंस्टॉल करें!",
+      "enterMeter": "कृपया एक मीटर नंबर दर्ज करें।",
+      "enterValidAmount": "कृपया 0 से अधिक एक वैध राशि दर्ज करें।",
+      "wholeNumber": "राशि एक पूर्ण संख्या होनी चाहिए।",
+      "amountTooLarge": "राशि बहुत अधिक है।",
+      "insufficientBalance": "अपर्याप्त शेष। कृपया अपने वॉलेट में अधिक XLM जोड़ें।",
+      "estimatingFees": "लेनदेन शुल्क का अनुमान लगाया जा रहा है... कृपया प्रतीक्षा करें।",
+      "estimationFailed": "लेनदेन शुल्क का अनुमान लगाने में असमर्थ। कृपया पुनः प्रयास करें।",
+      "paymentSuccess": "भुगतान सफल! लेनदेन आईडी: {{id}}...",
+      "paymentFailed": "भुगतान विफल: {{error}}"
     },
     "feeEstimation": {
-      "title": "Transaction Fee Estimation",
-      "calculating": "(Calculating...)",
-      "calculatingFees": "Calculating estimated fees...",
-      "paymentAmount": "Payment Amount",
-      "estimatedNetworkFee": "Estimated Network Fee",
-      "totalCost": "Total Cost",
-      "unableToEstimate": "Unable to estimate fees at this time"
+      "title": "लेनदेन शुल्क अनुमान",
+      "calculating": "(गणना हो रही है...)",
+      "calculatingFees": "अनुमानित शुल्क की गणना की जा रही है...",
+      "paymentAmount": "भुगतान राशि",
+      "estimatedNetworkFee": "अनुमानित नेटवर्क शुल्क",
+      "totalCost": "कुल लागत",
+      "unableToEstimate": "इस समय शुल्क का अनुमान लगाने में असमर्थ"
     },
     "rateLimit": {
-      "title": "Rate Limit Status",
-      "requestsAvailable": "{{count}}/5 requests available",
-      "rateLimited": "Rate limited. Reset in {{time}}",
-      "queue": "Queue: {{count}}"
+      "title": "अनुरोध सीमा स्थिति",
+      "requestsAvailable": "{{count}}/5 अनुरोध उपलब्ध",
+      "rateLimited": "सीमा पार हो गई। {{time}} में रीसेट होगी",
+      "queue": "प्रतीक्षा सूची: {{count}}"
     }
   },
   "wallet": {
     "balance": {
-      "title": "Wallet Balance",
-      "available": "Available Balance",
-      "total": "Total Balance",
-      "loading": "Loading balance...",
-      "error": "Failed to load balance",
-      "reconnect": "Please reconnect your wallet",
-      "insufficient": "Insufficient balance for this transaction",
-      "lowBalance": "Low balance warning"
+      "title": "वॉलेट शेष",
+      "available": "उपलब्ध शेष",
+      "total": "कुल शेष",
+      "loading": "शेष लोड हो रहा है...",
+      "error": "शेष लोड करने में विफल",
+      "reconnect": "कृपया अपना वॉलेट पुनः कनेक्ट करें",
+      "insufficient": "इस लेनदेन के लिए अपर्याप्त शेष",
+      "lowBalance": "कम शेष की चेतावनी"
     },
     "connection": {
-      "connected": "Connected",
-      "disconnected": "Disconnected",
-      "connecting": "Connecting...",
-      "connectWallet": "Connect Wallet",
-      "switchWallet": "Switch Wallet"
+      "connected": "जुड़ा हुआ",
+      "disconnected": "डिस्कनेक्ट",
+      "connecting": "जोड़ रहा है...",
+      "connectWallet": "वॉलेट कनेक्ट करें",
+      "switchWallet": "वॉलेट बदलें"
     }
   },
   "network": {
-    "mainnet": "MAINNET",
-    "testnet": "TESTNET",
-    "switchNetwork": "Switch Network",
-    "currentNetwork": "Current Network"
+    "mainnet": "मुख्य नेटवर्क",
+    "testnet": "परीक्षण नेटवर्क",
+    "switchNetwork": "नेटवर्क बदलें",
+    "currentNetwork": "वर्तमान नेटवर्क",
+    "switchTo": "{{network}} पर स्विच करें?",
+    "mainnetWarning": "चेतावनी: यह एक उत्पादन नेटवर्क है। वास्तविक धनराशि का उपयोग किया जाएगा।",
+    "testnetInfo": "आप Stellar परीक्षण नेटवर्क पर स्विच कर रहे हैं। लेनदेन परीक्षण XLM का उपयोग करेंगे।",
+    "mainnetConfirm": "आप लाइव Stellar मुख्य नेटवर्क पर स्विच करने वाले हैं। लेनदेन वास्तविक XLM का उपयोग करेंगे।",
+    "cancel": "रद्द करें",
+    "confirm": "पुष्टि करें"
   },
   "offline": {
     "banner": {
-      "title": "You're offline",
-      "description": "Some features may be unavailable. Actions will be queued and processed when you're back online.",
-      "retry": "Retry Connection",
-      "details": "Connection Details"
+      "title": "आप ऑफलाइन हैं",
+      "description": "कुछ सुविधाएं उपलब्ध नहीं हो सकती हैं। कार्य प्रतीक्षा सूची में डाले जाएंगे और जब आप वापस ऑनलाइन होंगे तब संसाधित किए जाएंगे।",
+      "retry": "पुनः प्रयास करें",
+      "details": "कनेक्शन विवरण"
     },
     "status": {
-      "online": "Online",
-      "offline": "Offline",
-      "connecting": "Connecting...",
-      "queueStatus": "{{count}} queued action",
-      "queueStatus_plural": "{{count}} queued actions"
+      "online": "ऑनलाइन",
+      "offline": "ऑफलाइन",
+      "connecting": "जोड़ रहा है...",
+      "queueStatus": "{{count}} कार्य प्रतीक्षा में",
+      "queueStatus_plural": "{{count}} कार्य प्रतीक्षा में"
     },
     "queue": {
-      "title": "Offline Queue",
-      "description": "{{count}} action will be processed when you're back online",
-      "description_plural": "{{count}} actions will be processed when you're back online"
+      "title": "ऑफलाइन प्रतीक्षा सूची",
+      "description": "जब आप वापस ऑनलाइन होंगे तब {{count}} कार्य संसाधित किया जाएगा",
+      "description_plural": "जब आप वापस ऑनलाइन होंगे तब {{count}} कार्य संसाधित किए जाएंगे"
     },
     "error": {
-      "paymentOffline": "Payment queued for when you're back online",
-      "generalOffline": "Action queued for when you're back online"
+      "paymentOffline": "भुगतान प्रतीक्षा सूची में है, ऑनलाइन होने पर संसाधित होगा",
+      "generalOffline": "कार्य प्रतीक्षा सूची में है, ऑनलाइन होने पर संसाधित होगा"
     }
   },
   "about": {
-    "title": "About Wata-Board",
-    "description": "Wata-Board is a decentralized utility payment platform built on the Stellar blockchain. We enable secure, transparent, and efficient utility bill payments using cryptocurrency.",
+    "title": "Wata-Board के बारे में",
+    "description": "Wata-Board Stellar ब्लॉकचेन पर बनी एक विकेंद्रीकृत उपयोगिता भुगतान प्लेटफॉर्म है। हम क्रिप्टोकरेंसी का उपयोग करके सुरक्षित, पारदर्शी और कुशल उपयोगिता बिल भुगतान सक्षम करते हैं।",
     "features": {
-      "title": "Key Features",
-      "secure": "Secure Transactions",
-      "secureDescription": "Built on Stellar blockchain with enterprise-grade security",
-      "fast": "Fast Payments",
-      "fastDescription": "Near-instant settlement with low transaction fees",
-      "transparent": "Transparent Records",
-      "transparentDescription": "All transactions are recorded on the public blockchain",
-      "decentralized": "Decentralized",
-      "decentralizedDescription": "No single point of failure or control"
+      "title": "मुख्य विशेषताएं",
+      "secure": "सुरक्षित लेनदेन",
+      "secureDescription": "एंटरप्राइज-ग्रेड सुरक्षा के साथ Stellar ब्लॉकचेन पर निर्मित",
+      "fast": "त्वरित भुगतान",
+      "fastDescription": "कम लेनदेन शुल्क के साथ लगभग तत्काल निपटान",
+      "transparent": "पारदर्शी रिकॉर्ड",
+      "transparentDescription": "सभी लेनदेन सार्वजनिक ब्लॉकचेन पर दर्ज किए जाते हैं",
+      "decentralized": "विकेंद्रीकृत",
+      "decentralizedDescription": "विफलता या नियंत्रण का कोई एकल बिंदु नहीं"
     },
     "howItWorks": {
-      "title": "How It Works",
-      "step1": "Connect your wallet",
-      "step2": "Enter meter details",
-      "step3": "Confirm payment",
-      "step4": "Payment processed"
+      "title": "यह कैसे काम करता है",
+      "step1": "अपना वॉलेट कनेक्ट करें",
+      "step2": "मीटर विवरण दर्ज करें",
+      "step3": "भुगतान की पुष्टि करें",
+      "step4": "भुगतान संसाधित हुआ"
     }
   },
   "contact": {
-    "title": "Contact Us",
-    "description": "Get in touch with our team for support, questions, or feedback.",
+    "title": "संपर्क करें",
+    "description": "समर्थन, प्रश्नों या प्रतिक्रिया के लिए हमारी टीम से संपर्क करें।",
     "form": {
-      "name": "Name",
-      "namePlaceholder": "Enter your name",
-      "email": "Email",
-      "emailPlaceholder": "Enter your email",
-      "subject": "Subject",
-      "subjectPlaceholder": "Enter subject",
-      "message": "Message",
-      "messagePlaceholder": "Enter your message",
-      "sendButton": "Send Message",
-      "sending": "Sending..."
+      "name": "नाम",
+      "namePlaceholder": "अपना नाम दर्ज करें",
+      "email": "ईमेल",
+      "emailPlaceholder": "अपना ईमेल दर्ज करें",
+      "subject": "विषय",
+      "subjectPlaceholder": "विषय दर्ज करें",
+      "message": "संदेश",
+      "messagePlaceholder": "अपना संदेश दर्ज करें",
+      "sendButton": "संदेश भेजें",
+      "sending": "भेज रहा है..."
     },
     "info": {
-      "email": "Email",
-      "support": "Support",
-      "website": "Website"
+      "email": "ईमेल",
+      "support": "सहायता",
+      "website": "वेबसाइट"
     }
   },
   "rate": {
-    "title": "Rate Your Experience",
-    "description": "Help us improve by rating your experience with Wata-Board.",
+    "title": "अपना अनुभव रेट करें",
+    "description": "Wata-Board के साथ अपने अनुभव को रेट करके हमें बेहतर बनाने में मदद करें।",
     "rating": {
-      "excellent": "Excellent",
-      "good": "Good",
-      "average": "Average",
-      "poor": "Poor",
-      "terrible": "Terrible"
+      "excellent": "उत्कृष्ट",
+      "good": "अच्छा",
+      "average": "औसत",
+      "poor": "खराब",
+      "terrible": "बहुत खराब"
     },
     "review": {
-      "title": "Write a Review",
-      "placeholder": "Share your experience with Wata-Board...",
-      "submit": "Submit Review",
-      "thankYou": "Thank you for your feedback!"
+      "title": "समीक्षा लिखें",
+      "placeholder": "Wata-Board के साथ अपना अनुभव साझा करें...",
+      "submit": "समीक्षा जमा करें",
+      "thankYou": "आपकी प्रतिक्रिया के लिए धन्यवाद!"
     }
   },
   "errors": {
     "general": {
-      "title": "Error",
-      "unknown": "An unknown error occurred",
-      "tryAgain": "Please try again",
-      "contactSupport": "Contact support if the problem persists"
+      "title": "त्रुटि",
+      "unknown": "एक अज्ञात त्रुटि हुई",
+      "tryAgain": "कृपया पुनः प्रयास करें",
+      "contactSupport": "यदि समस्या बनी रहती है तो सहायता से संपर्क करें"
     },
     "network": {
-      "title": "Network Error",
-      "description": "Unable to connect to the network",
-      "checkConnection": "Please check your internet connection"
+      "title": "नेटवर्क त्रुटि",
+      "description": "नेटवर्क से कनेक्ट होने में असमर्थ",
+      "checkConnection": "कृपया अपना इंटरनेट कनेक्शन जांचें"
     },
     "wallet": {
-      "title": "Wallet Error",
-      "notConnected": "Wallet not connected",
-      "notInstalled": "Freighter wallet not installed",
-      "installFreighter": "Please install Freighter wallet extension"
+      "title": "वॉलेट त्रुटि",
+      "notConnected": "वॉलेट कनेक्ट नहीं है",
+      "notInstalled": "Freighter वॉलेट इंस्टॉल नहीं है",
+      "installFreighter": "कृपया Freighter वॉलेट एक्सटेंशन इंस्टॉल करें"
     }
   },
   "accessibility": {
-    "skipToMain": "Skip to main content",
-    "skipToNavigation": "Skip to navigation",
-    "menuToggle": "Toggle navigation menu",
-    "closeMenu": "Close menu",
-    "openMenu": "Open menu",
-    "loading": "Loading...",
-    "error": "Error",
-    "success": "Success",
-    "warning": "Warning",
-    "info": "Information"
+    "skipToMain": "मुख्य सामग्री पर जाएं",
+    "skipToNavigation": "नेविगेशन पर जाएं",
+    "menuToggle": "नेविगेशन मेनू टॉगल करें",
+    "closeMenu": "मेनू बंद करें",
+    "openMenu": "मेनू खोलें",
+    "loading": "लोड हो रहा है...",
+    "error": "त्रुटि",
+    "success": "सफलता",
+    "warning": "चेतावनी",
+    "info": "जानकारी"
   },
   "common": {
-    "cancel": "Cancel",
-    "confirm": "Confirm",
-    "save": "Save",
-    "delete": "Delete",
-    "edit": "Edit",
-    "close": "Close",
-    "back": "Back",
-    "next": "Next",
-    "previous": "Previous",
-    "submit": "Submit",
-    "reset": "Reset",
-    "clear": "Clear",
-    "search": "Search",
-    "filter": "Filter",
-    "sort": "Sort",
-    "loading": "Loading...",
-    "error": "Error",
-    "success": "Success",
-    "retry": "Retry",
-    "refresh": "Refresh",
-    "copy": "Copy",
-    "copied": "Copied!",
-    "learnMore": "Learn More",
-    "viewDetails": "View Details",
-    "hideDetails": "Hide Details"
+    "cancel": "रद्द करें",
+    "confirm": "पुष्टि करें",
+    "save": "सहेजें",
+    "delete": "हटाएं",
+    "edit": "संपादित करें",
+    "close": "बंद करें",
+    "back": "वापस",
+    "next": "अगला",
+    "previous": "पिछला",
+    "submit": "जमा करें",
+    "reset": "रीसेट करें",
+    "clear": "साफ करें",
+    "search": "खोजें",
+    "filter": "फ़िल्टर करें",
+    "sort": "क्रमबद्ध करें",
+    "loading": "लोड हो रहा है...",
+    "error": "त्रुटि",
+    "success": "सफलता",
+    "retry": "पुनः प्रयास करें",
+    "refresh": "ताज़ा करें",
+    "copy": "कॉपी करें",
+    "copied": "कॉपी हो गया!",
+    "learnMore": "अधिक जानें",
+    "viewDetails": "विवरण देखें",
+    "hideDetails": "विवरण छिपाएं"
   },
   "time": {
-    "seconds": "second",
-    "seconds_plural": "seconds",
-    "minutes": "minute",
-    "minutes_plural": "minutes",
-    "hours": "hour",
-    "hours_plural": "hours",
-    "days": "day",
-    "days_plural": "days",
-    "weeks": "week",
-    "weeks_plural": "weeks",
-    "months": "month",
-    "months_plural": "months",
-    "years": "year",
-    "years_plural": "years",
-    "ago": "{{time}} ago",
-    "in": "in {{time}}"
+    "seconds": "सेकंड",
+    "seconds_plural": "सेकंड",
+    "minutes": "मिनट",
+    "minutes_plural": "मिनट",
+    "hours": "घंटा",
+    "hours_plural": "घंटे",
+    "days": "दिन",
+    "days_plural": "दिन",
+    "weeks": "सप्ताह",
+    "weeks_plural": "सप्ताह",
+    "months": "महीना",
+    "months_plural": "महीने",
+    "years": "साल",
+    "years_plural": "साल",
+    "ago": "{{time}} पहले",
+    "in": "{{time}} में"
   },
   "currency": {
     "xlm": "XLM",
@@ -245,13 +255,13 @@
     "eur": "EUR"
   },
   "validation": {
-    "required": "This field is required",
-    "invalid": "Invalid format",
-    "tooShort": "Must be at least {{min}} characters",
-    "tooLong": "Must be no more than {{max}} characters",
-    "invalidEmail": "Please enter a valid email address",
-    "invalidNumber": "Please enter a valid number",
-    "minValue": "Must be at least {{min}}",
-    "maxValue": "Must be no more than {{max}}"
+    "required": "यह फ़ील्ड आवश्यक है",
+    "invalid": "अमान्य प्रारूप",
+    "tooShort": "कम से कम {{min}} अक्षर होने चाहिए",
+    "tooLong": "अधिकतम {{max}} अक्षर होने चाहिए",
+    "invalidEmail": "कृपया एक वैध ईमेल पता दर्ज करें",
+    "invalidNumber": "कृपया एक वैध संख्या दर्ज करें",
+    "minValue": "कम से कम {{min}} होना चाहिए",
+    "maxValue": "अधिकतम {{max}} होना चाहिए"
   }
 }


### PR DESCRIPTION
  ## Summary

  Reimplements the Hindi localization file `wata-board-frontend/src/i18n/locales/hi.json`, which had been deleted. This restores full Hindi (Devanagari script)  support for the app — important given Hindi is spoken by 600M+ people, primarily in India, one of the fastest-growing crypto markets.

  ## Changes

  - **Translated all UI strings to Hindi** in Devanagari script across every section: `app`, `navigation`, `payment`, `wallet`, `network`, `offline`, `about`,
  `contact`, `rate`, `errors`, `accessibility`, `common`, `time`, `currency`, and `validation`.
  - **Hindi pluralization** handled via i18next `_plural` keys (e.g. `घंटा`/`घंटे`,`महीना`/`महीने`keeping invariable forms where the language requires them (`मिनट`,
  `दिन`,`सप्ताह`).
  - **Number formats** kept consistent with the source: literal numerals and `{{count}}`/`{{amount}}` interpolations match `en.json` and are formatted at
  runtime via `Intl` based on the active locale.
  - **Interpolation placeholders** (`{{id}}`, `{{count}}`, `{{time}}`, `{{error}}`, `{{network}}`, `{{min}}`, `{{max}}`) preserved and aligned key-by-key with
  `en.json`.

  ## Acceptance criteria

  - [x] All UI strings are translated
  - [x] Handle Hindi pluralization rules
  - [x] Use correct date and number formats
  - [ ] Devanagari script renders correctly *(verify in-app / font support)*
  - [x] No untranslated strings in Hindi mode
  - [ ] Translations reviewed by a native speaker *(see note below)*

  ## ⚠️  Note: native speaker review

  This PR closes #368, but the acceptance criterion **"Translations are reviewed by a native speaker"** has **not** yet been fulfilled. The Hindi strings were
  produced and self-checked for grammatical/pluralization correctness, but a native Hindi speaker should review them before/after merge. Please flag any
  phrasing that should be refined in a follow-up.

## Local environment note
The app has pre-existing build/runtime errors unrelated to this PR 
that prevent `npm run dev` from running locally. Since this PR only 
adds `hi.json` (a static JSON file with no logic), correct rendering 
depends entirely on the app's existing i18n setup and font support, 
which are outside the scope of this change.

 Closes #368