### PR TITLE
feat(reminders): add BullMQ processor, cron scheduler, and unit tests

### DIFF
--- a/backend/src/modules/reminders/entities/reminder.entity.ts
+++ b/backend/src/modules/reminders/entities/reminder.entity.ts
@@ -28,6 +28,7 @@ export enum ReminderStatus {
   OVERDUE = 'OVERDUE',
   SNOOZED = 'SNOOZED',
   CANCELLED = 'CANCELLED',
+  FAILED = 'FAILED',
 }
 
 @Entity('reminders')

--- a/backend/src/modules/reminders/reminder.processor.spec.ts
+++ b/backend/src/modules/reminders/reminder.processor.spec.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bullmq';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Job } from 'bullmq';
+import { ReminderProcessor } from './reminder.processor';
+import { ReminderScheduler } from './reminder.scheduler';
+import { ReminderService } from './reminder.service';
+import { Reminder, ReminderStatus, ReminderType } from './entities/reminder.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationCategory } from '../notifications/entities/notification.entity';
+
+const mockReminder = (overrides: Partial<Reminder> = {}): Reminder =>
+  ({
+    id: 'rem-1',
+    userId: 'user-1',
+    petId: 'pet-1',
+    title: 'Rabies Vaccine',
+    description: 'Annual rabies vaccination',
+    status: ReminderStatus.PENDING,
+    type: ReminderType.VACCINATION,
+    dueDate: new Date(Date.now() + 3600 * 1000),
+    ...overrides,
+  }) as Reminder;
+
+const makeJob = (data: { reminderId: string }, opts: Partial<Job> = {}): Job =>
+  ({
+    id: 'job-1',
+    data,
+    opts: { attempts: 3 },
+    attemptsMade: 0,
+    ...opts,
+  }) as unknown as Job;
+
+describe('ReminderProcessor', () => {
+  let processor: ReminderProcessor;
+  let reminderService: jest.Mocked<ReminderService>;
+  let notificationsService: jest.Mocked<NotificationsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReminderProcessor,
+        {
+          provide: ReminderService,
+          useValue: {
+            findOne: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: { create: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    processor = module.get(ReminderProcessor);
+    reminderService = module.get(ReminderService);
+    notificationsService = module.get(NotificationsService);
+  });
+
+  it('dispatches notification and marks SENT_DAY_OF for a PENDING reminder', async () => {
+    const reminder = mockReminder();
+    reminderService.findOne.mockResolvedValue(reminder);
+    notificationsService.create.mockResolvedValue({} as any);
+    reminderService.update.mockResolvedValue({ ...reminder, status: ReminderStatus.SENT_DAY_OF } as any);
+
+    await processor.process(makeJob({ reminderId: 'rem-1' }));
+
+    expect(notificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        category: NotificationCategory.VACCINATION,
+        metadata: { reminderId: 'rem-1', petId: 'pet-1' },
+      }),
+    );
+    expect(reminderService.update).toHaveBeenCalledWith('rem-1', {
+      status: ReminderStatus.SENT_DAY_OF,
+    });
+  });
+
+  it('skips dispatch when reminder is not PENDING', async () => {
+    reminderService.findOne.mockResolvedValue(mockReminder({ status: ReminderStatus.COMPLETED }));
+
+    await processor.process(makeJob({ reminderId: 'rem-1' }));
+
+    expect(notificationsService.create).not.toHaveBeenCalled();
+    expect(reminderService.update).not.toHaveBeenCalled();
+  });
+
+  it('marks FAILED and re-throws on final attempt failure', async () => {
+    reminderService.findOne.mockResolvedValue(mockReminder());
+    notificationsService.create.mockRejectedValue(new Error('FCM error'));
+    reminderService.update.mockResolvedValue({} as any);
+
+    const job = makeJob({ reminderId: 'rem-1' }, { attemptsMade: 2, opts: { attempts: 3 } } as any);
+
+    await expect(processor.process(job)).rejects.toThrow('FCM error');
+
+    expect(reminderService.update).toHaveBeenCalledWith('rem-1', {
+      status: ReminderStatus.FAILED,
+    });
+  });
+
+  it('re-throws without marking FAILED on non-final attempt', async () => {
+    reminderService.findOne.mockResolvedValue(mockReminder());
+    notificationsService.create.mockRejectedValue(new Error('transient'));
+    reminderService.update.mockResolvedValue({} as any);
+
+    const job = makeJob({ reminderId: 'rem-1' }, { attemptsMade: 0, opts: { attempts: 3 } } as any);
+
+    await expect(processor.process(job)).rejects.toThrow('transient');
+
+    expect(reminderService.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReminderScheduler', () => {
+  let scheduler: ReminderScheduler;
+  let reminderRepo: { find: jest.Mock };
+  let remindersQueue: { add: jest.Mock; getJob: jest.Mock };
+
+  beforeEach(async () => {
+    reminderRepo = { find: jest.fn() };
+    remindersQueue = { add: jest.fn(), getJob: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReminderScheduler,
+        {
+          provide: getQueueToken('reminders'),
+          useValue: remindersQueue,
+        },
+        {
+          provide: getRepositoryToken(Reminder),
+          useValue: reminderRepo,
+        },
+      ],
+    }).compile();
+
+    scheduler = module.get(ReminderScheduler);
+  });
+
+  it('enqueues PENDING reminders due within 24 hours', async () => {
+    const reminder = mockReminder();
+    reminderRepo.find.mockResolvedValue([reminder]);
+    remindersQueue.getJob.mockResolvedValue(null);
+    remindersQueue.add.mockResolvedValue({});
+
+    await scheduler.scheduleUpcomingReminders();
+
+    expect(remindersQueue.add).toHaveBeenCalledWith(
+      'dispatch',
+      { reminderId: 'rem-1' },
+      expect.objectContaining({
+        jobId: 'reminder:rem-1',
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+      }),
+    );
+  });
+
+  it('skips reminders that are already enqueued', async () => {
+    reminderRepo.find.mockResolvedValue([mockReminder()]);
+    remindersQueue.getJob.mockResolvedValue({ id: 'reminder:rem-1' }); // already exists
+
+    await scheduler.scheduleUpcomingReminders();
+
+    expect(remindersQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no reminders are due', async () => {
+    reminderRepo.find.mockResolvedValue([]);
+
+    await scheduler.scheduleUpcomingReminders();
+
+    expect(remindersQueue.add).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/reminders/reminder.processor.ts
+++ b/backend/src/modules/reminders/reminder.processor.ts
@@ -1,0 +1,62 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { NotificationsService } from '../notifications/notifications.service';
+import { ReminderService } from './reminder.service';
+import { ReminderStatus } from './entities/reminder.entity';
+import { NotificationCategory } from '../notifications/entities/notification.entity';
+
+export interface ReminderJobData {
+  reminderId: string;
+}
+
+@Processor('reminders')
+export class ReminderProcessor extends WorkerHost {
+  private readonly logger = new Logger(ReminderProcessor.name);
+
+  constructor(
+    private readonly reminderService: ReminderService,
+    private readonly notificationsService: NotificationsService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<ReminderJobData>): Promise<void> {
+    const { reminderId } = job.data;
+    this.logger.log(`Processing reminder job ${job.id} for reminder ${reminderId}`);
+
+    const reminder = await this.reminderService.findOne(reminderId);
+
+    if (reminder.status !== ReminderStatus.PENDING) {
+      this.logger.log(`Reminder ${reminderId} is not PENDING (status: ${reminder.status}), skipping`);
+      return;
+    }
+
+    try {
+      await this.notificationsService.create({
+        userId: reminder.userId,
+        title: reminder.title,
+        message: reminder.description ?? reminder.title,
+        category: NotificationCategory.VACCINATION,
+        metadata: { reminderId: reminder.id, petId: reminder.petId },
+      });
+
+      await this.reminderService.update(reminderId, {
+        status: ReminderStatus.SENT_DAY_OF,
+      });
+
+      this.logger.log(`Reminder ${reminderId} dispatched successfully`);
+    } catch (err: any) {
+      this.logger.error(`Failed to dispatch reminder ${reminderId}: ${err?.message}`);
+
+      // Mark FAILED only after all BullMQ retries are exhausted
+      if (job.attemptsMade >= (job.opts.attempts ?? 1) - 1) {
+        await this.reminderService.update(reminderId, {
+          status: ReminderStatus.FAILED,
+        });
+      }
+
+      throw err; // re-throw so BullMQ applies retry/backoff
+    }
+  }
+}

--- a/backend/src/modules/reminders/reminder.scheduler.ts
+++ b/backend/src/modules/reminders/reminder.scheduler.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { Reminder, ReminderStatus } from './entities/reminder.entity';
+import { ReminderJobData } from './reminder.processor';
+
+@Injectable()
+export class ReminderScheduler {
+  private readonly logger = new Logger(ReminderScheduler.name);
+
+  constructor(
+    @InjectQueue('reminders') private readonly remindersQueue: Queue,
+    @InjectRepository(Reminder)
+    private readonly reminderRepository: Repository<Reminder>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async scheduleUpcomingReminders(): Promise<void> {
+    const now = new Date();
+    const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+    const reminders = await this.reminderRepository.find({
+      where: {
+        status: ReminderStatus.PENDING,
+        dueDate: Between(now, in24h),
+      },
+    });
+
+    this.logger.log(`Found ${reminders.length} reminders due within 24 hours`);
+
+    for (const reminder of reminders) {
+      const jobId = `reminder:${reminder.id}`;
+      const delay = Math.max(0, reminder.dueDate.getTime() - Date.now());
+
+      // Check if job already exists to avoid double-enqueuing
+      const existing = await this.remindersQueue.getJob(jobId);
+      if (existing) {
+        this.logger.debug(`Reminder ${reminder.id} already enqueued, skipping`);
+        continue;
+      }
+
+      await this.remindersQueue.add(
+        'dispatch',
+        { reminderId: reminder.id } satisfies ReminderJobData,
+        {
+          jobId,
+          delay,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5000 },
+          removeOnComplete: true,
+          removeOnFail: false,
+        },
+      );
+
+      this.logger.log(`Enqueued reminder ${reminder.id} with delay ${delay}ms`);
+    }
+  }
+}

--- a/backend/src/modules/reminders/reminders.module.ts
+++ b/backend/src/modules/reminders/reminders.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bullmq';
 import { Reminder } from './entities/reminder.entity';
 import { Pet } from '../pets/entities/pet.entity';
 import { VaccinationSchedule } from '../vaccinations/entities/vaccination-schedule.entity';
@@ -7,13 +8,18 @@ import { User } from '../users/entities/user.entity';
 import { ReminderService } from './reminder.service';
 import { BatchProcessingService } from './batch-processing.service';
 import { RemindersController } from './reminders.controller';
+import { ReminderProcessor } from './reminder.processor';
+import { ReminderScheduler } from './reminder.scheduler';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Reminder, Pet, VaccinationSchedule, User]),
+    BullModule.registerQueue({ name: 'reminders' }),
+    NotificationsModule,
   ],
   controllers: [RemindersController],
-  providers: [ReminderService, BatchProcessingService],
+  providers: [ReminderService, BatchProcessingService, ReminderProcessor, ReminderScheduler],
   exports: [ReminderService, BatchProcessingService],
 })
 export class RemindersModule {}


### PR DESCRIPTION
feat(reminders): implement BullMQ reminder dispatch pipeline
  
  Summary
  
  Vaccination reminders were being created in the database but never delivered. This PR wires up
  the missing dispatch layer.
  
  Changes
  
  - ReminderProcessor — BullMQ @Processor('reminders') that loads a pending reminder, dispatches
  it via NotificationsService, and transitions status to SENT_DAY_OF. Retries up to 3 times with
  exponential backoff; marks FAILED only after all attempts are exhausted.
  - ReminderScheduler — @Cron(EVERY_HOUR) job that queries PENDING reminders due within the next
  24 hours and enqueues each with a delay matching dueDate. Uses jobId: reminder:{id} to prevent
  duplicate enqueues.
  - RemindersModule — registers the reminders BullMQ queue, NotificationsModule, and the two new
  providers.
  - ReminderStatus — added FAILED enum value.
  - Unit tests — covers dispatch success, skip non-pending, FAILED on final retry, no FAILED on
  intermediate retry, idempotent enqueue, and empty-result no-op.
  
  Testing
  
  - All new behaviour is covered by mocked unit tests in reminder.processor.spec.ts
  - ScheduleModule.forRoot() is already global in AppModule — no additional setup required
closes #488