### PR TITLE
feat(observability): wire Prometheus metrics endpoint, health check with DB/Redis, business metrics

### DIFF
--- a/backend/src/modules/observability/metrics.service.ts
+++ b/backend/src/modules/observability/metrics.service.ts
@@ -211,4 +211,22 @@ export class MetricsService {
 
     return buckets[buckets.length - 1] ?? 0;
   }
+
+  // ── Business Metrics ───────────────────────────────────────────────────────
+
+  setPetsTotal(count: number): void {
+    this.set('petchain_pets_total', count);
+  }
+
+  setMedicalRecordsTotal(count: number): void {
+    this.set('petchain_medical_records_total', count);
+  }
+
+  incBlockchainSync(status: 'success' | 'failed'): void {
+    this.inc('petchain_blockchain_syncs_total', `status="${status}"`);
+  }
+
+  setActiveSessions(count: number): void {
+    this.set('petchain_active_sessions_total', count);
+  }
 }

--- a/backend/src/modules/observability/observability.controller.ts
+++ b/backend/src/modules/observability/observability.controller.ts
@@ -1,5 +1,15 @@
-import { Controller, Get, Res, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Res,
+  HttpCode,
+  HttpStatus,
+  UnauthorizedException,
+  Headers,
+} from '@nestjs/common';
 import { Response } from 'express';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { MetricsService } from './metrics.service';
 import { AlertingService } from './alerting.service';
 import { PerformanceInsightsService } from './performance-insights.service';
@@ -10,20 +20,37 @@ export class ObservabilityController {
     private readonly metrics: MetricsService,
     private readonly alerting: AlertingService,
     private readonly performanceInsights: PerformanceInsightsService,
+    @InjectDataSource() private readonly dataSource: DataSource,
   ) {}
 
-  /** GET /observability/metrics — Prometheus scrape endpoint */
+  /** GET /observability/metrics — Prometheus scrape endpoint (token-protected) */
   @Get('metrics')
   @HttpCode(HttpStatus.OK)
-  getMetrics(@Res() res: Response): void {
+  getMetrics(
+    @Res() res: Response,
+    @Headers('x-metrics-token') token: string,
+  ): void {
+    const expected = process.env.METRICS_TOKEN;
+    if (expected && token !== expected) {
+      throw new UnauthorizedException('Invalid metrics token');
+    }
     res.setHeader('Content-Type', 'text/plain; version=0.0.4');
     res.send(this.metrics.render());
   }
 
-  /** GET /observability/health — liveness probe */
+  /** GET /observability/health — liveness + DB + Redis probe */
   @Get('health')
-  health() {
-    return { status: 'ok', timestamp: new Date().toISOString() };
+  async health() {
+    const [db, redis] = await Promise.all([
+      this.checkDb(),
+      this.checkRedis(),
+    ]);
+    return {
+      status: db === 'connected' && redis === 'connected' ? 'ok' : 'degraded',
+      uptime: process.uptime(),
+      db,
+      redis,
+    };
   }
 
   /** GET /observability/alerts — active alert list */
@@ -37,5 +64,32 @@ export class ObservabilityController {
   @Get('performance')
   performance() {
     return this.performanceInsights.getSummary();
+  }
+
+  private async checkDb(): Promise<'connected' | 'error'> {
+    try {
+      await this.dataSource.query('SELECT 1');
+      return 'connected';
+    } catch {
+      return 'error';
+    }
+  }
+
+  private async checkRedis(): Promise<'connected' | 'error'> {
+    try {
+      // ioredis client may be available via cache manager; attempt a simple ping
+      const { Redis } = await import('ioredis');
+      const client = new Redis({
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379'),
+        lazyConnect: true,
+        connectTimeout: 2000,
+      });
+      await client.ping();
+      await client.quit();
+      return 'connected';
+    } catch {
+      return 'error';
+    }
   }
 }

--- a/backend/src/modules/observability/observability.module.ts
+++ b/backend/src/modules/observability/observability.module.ts
@@ -1,5 +1,6 @@
 import { Module, Global } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MetricsService } from './metrics.service';
 import { TracingService } from './tracing.service';
 import { LogAggregatorService } from './log-aggregator.service';
@@ -11,6 +12,7 @@ import { PerformanceInsightsService } from './performance-insights.service';
 
 @Global()
 @Module({
+  imports: [TypeOrmModule.forFeature([])],
   controllers: [ObservabilityController],
   providers: [
     MetricsService,


### PR DESCRIPTION
Closes #502

- `GET /observability/metrics` protected by `METRICS_TOKEN` header
- `GET /observability/health` returns DB and Redis status
- Business metrics: `petchain_pets_total`, `petchain_medical_records_total`, `petchain_blockchain_syncs_total`, `petchain_active_sessions_total`
- `HttpMetricsInterceptor` already applied globally via `APP_INTERCEPTOR`