### PR TITLE
feat(audit): add queryable audit log API with filtering, pagination, and CSV export

### DIFF
--- a/backend/src/modules/audit/audit.controller.ts
+++ b/backend/src/modules/audit/audit.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Res,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { AuditService } from './audit.service';
+import { AuditQueryDto } from './dto/audit-query.dto';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { RoleName } from '../../auth/constants/roles.enum';
+
+@Controller('audit')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  /** GET /audit — admin: query all logs with filters */
+  @Get()
+  @Roles(RoleName.Admin)
+  findAll(@Query() query: AuditQueryDto) {
+    return this.auditService.findAll(query);
+  }
+
+  /** GET /audit/me — authenticated user: own audit trail */
+  @Get('me')
+  findMine(@Request() req: { user: { id: string } }) {
+    return this.auditService.findByUser(req.user.id);
+  }
+
+  /** GET /audit/entity/:entityType/:entityId — admin: logs for a specific entity */
+  @Get('entity/:entityType/:entityId')
+  @Roles(RoleName.Admin)
+  findByEntity(
+    @Param('entityType') entityType: string,
+    @Param('entityId') entityId: string,
+  ) {
+    return this.auditService.findByEntity(entityType, entityId);
+  }
+
+  /** GET /audit/export — admin: stream CSV download */
+  @Get('export')
+  @Roles(RoleName.Admin)
+  async exportCsv(@Query() query: AuditQueryDto, @Res() res: Response) {
+    const csv = await this.auditService.exportCsv(query);
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', 'attachment; filename="audit-logs.csv"');
+    res.send(csv);
+  }
+}

--- a/backend/src/modules/audit/audit.module.ts
+++ b/backend/src/modules/audit/audit.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuditService } from './audit.service';
+import { AuditController } from './audit.controller';
 import { AuditLog } from './entities/audit-log.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AuditLog])],
+  controllers: [AuditController],
   providers: [AuditService],
   exports: [AuditService],
 })

--- a/backend/src/modules/audit/audit.service.spec.ts
+++ b/backend/src/modules/audit/audit.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditService } from './audit.service';
+import { AuditLog, AuditAction } from './entities/audit-log.entity';
+
+const mockLog: AuditLog = {
+  id: 'log-1',
+  userId: 'user-1',
+  entityType: 'Pet',
+  entityId: 'pet-1',
+  action: AuditAction.READ,
+  ipAddress: '127.0.0.1',
+  userAgent: 'jest',
+  timestamp: new Date('2024-01-01T00:00:00Z'),
+} as AuditLog;
+
+const mockRepo = {
+  create: jest.fn().mockReturnValue(mockLog),
+  save: jest.fn().mockResolvedValue(mockLog),
+  find: jest.fn().mockResolvedValue([mockLog]),
+  findAndCount: jest.fn().mockResolvedValue([[mockLog], 1]),
+};
+
+describe('AuditService', () => {
+  let service: AuditService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        { provide: getRepositoryToken(AuditLog), useValue: mockRepo },
+      ],
+    }).compile();
+    service = module.get(AuditService);
+    jest.clearAllMocks();
+    mockRepo.create.mockReturnValue(mockLog);
+    mockRepo.save.mockResolvedValue(mockLog);
+    mockRepo.find.mockResolvedValue([mockLog]);
+    mockRepo.findAndCount.mockResolvedValue([[mockLog], 1]);
+  });
+
+  it('logs an audit entry', async () => {
+    const result = await service.log('user-1', 'Pet', 'pet-1', AuditAction.READ, '127.0.0.1');
+    expect(mockRepo.create).toHaveBeenCalled();
+    expect(mockRepo.save).toHaveBeenCalled();
+    expect(result).toEqual(mockLog);
+  });
+
+  it('findAll returns paginated results', async () => {
+    const result = await service.findAll({ page: 1, limit: 10 });
+    expect(result.data).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(10);
+  });
+
+  it('findAll filters by userId', async () => {
+    await service.findAll({ userId: 'user-1' });
+    expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ userId: 'user-1' }) }),
+    );
+  });
+
+  it('findAll filters by action', async () => {
+    await service.findAll({ action: AuditAction.DELETE });
+    expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ action: AuditAction.DELETE }) }),
+    );
+  });
+
+  it('findAll filters by date range', async () => {
+    await service.findAll({ dateFrom: '2024-01-01', dateTo: '2024-12-31' });
+    expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ timestamp: expect.anything() }) }),
+    );
+  });
+
+  it('findByEntity returns logs for entity', async () => {
+    const result = await service.findByEntity('Pet', 'pet-1');
+    expect(mockRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { entityType: 'Pet', entityId: 'pet-1' } }),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it('exportCsv returns a Buffer with CSV content', async () => {
+    const csv = await service.exportCsv({});
+    expect(csv).toBeInstanceOf(Buffer);
+    const content = csv.toString();
+    expect(content).toContain('id,userId,entityType');
+    expect(content).toContain('log-1');
+  });
+});

--- a/backend/src/modules/audit/audit.service.ts
+++ b/backend/src/modules/audit/audit.service.ts
@@ -1,7 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, Between, FindOptionsWhere } from 'typeorm';
 import { AuditLog, AuditAction } from './entities/audit-log.entity';
+import { AuditQueryDto } from './dto/audit-query.dto';
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
 
 @Injectable()
 export class AuditService {
@@ -26,24 +34,55 @@ export class AuditService {
       ipAddress,
       userAgent,
     });
-
-    return await this.auditLogRepository.save(auditLog);
+    return this.auditLogRepository.save(auditLog);
   }
 
-  async findByEntity(
-    entityType: string,
-    entityId: string,
-  ): Promise<AuditLog[]> {
-    return await this.auditLogRepository.find({
+  async findAll(query: AuditQueryDto): Promise<PaginatedResult<AuditLog>> {
+    const { userId, entityType, action, dateFrom, dateTo, order = 'DESC', page = 1, limit = 20 } = query;
+
+    const where: FindOptionsWhere<AuditLog> = {};
+    if (userId) where.userId = userId;
+    if (entityType) where.entityType = entityType;
+    if (action) where.action = action;
+    if (dateFrom || dateTo) {
+      where.timestamp = Between(
+        dateFrom ? new Date(dateFrom) : new Date(0),
+        dateTo ? new Date(dateTo) : new Date(),
+      );
+    }
+
+    const [data, total] = await this.auditLogRepository.findAndCount({
+      where,
+      order: { timestamp: order },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { data, total, page, limit };
+  }
+
+  async findByEntity(entityType: string, entityId: string): Promise<AuditLog[]> {
+    return this.auditLogRepository.find({
       where: { entityType, entityId },
       order: { timestamp: 'DESC' },
     });
   }
 
   async findByUser(userId: string): Promise<AuditLog[]> {
-    return await this.auditLogRepository.find({
+    return this.auditLogRepository.find({
       where: { userId },
       order: { timestamp: 'DESC' },
     });
+  }
+
+  async exportCsv(query: AuditQueryDto): Promise<Buffer> {
+    const { data } = await this.findAll({ ...query, limit: 10000, page: 1 });
+    const header = 'id,userId,entityType,entityId,action,ipAddress,userAgent,timestamp\n';
+    const rows = data.map((r) =>
+      [r.id, r.userId, r.entityType, r.entityId, r.action, r.ipAddress ?? '', r.userAgent ?? '', r.timestamp.toISOString()]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(','),
+    );
+    return Buffer.from(header + rows.join('\n'));
   }
 }

--- a/backend/src/modules/audit/dto/audit-query.dto.ts
+++ b/backend/src/modules/audit/dto/audit-query.dto.ts
@@ -1,0 +1,23 @@
+import {
+  IsOptional,
+  IsUUID,
+  IsString,
+  IsEnum,
+  IsDateString,
+  IsIn,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { AuditAction } from '../entities/audit-log.entity';
+
+export class AuditQueryDto {
+  @IsOptional() @IsUUID() userId?: string;
+  @IsOptional() @IsString() entityType?: string;
+  @IsOptional() @IsEnum(AuditAction) action?: AuditAction;
+  @IsOptional() @IsDateString() dateFrom?: string;
+  @IsOptional() @IsDateString() dateTo?: string;
+  @IsOptional() @IsIn(['ASC', 'DESC']) order?: 'ASC' | 'DESC';
+  @IsOptional() @Type(() => Number) @Min(1) page?: number;
+  @IsOptional() @Type(() => Number) @Min(1) @Max(100) limit?: number;
+}


### PR DESCRIPTION
Closes #504

- `GET /audit` — paginated, filterable by userId, entityType, action, date range (Admin only)
- `GET /audit/me` — authenticated user's own trail
- `GET /audit/entity/:entityType/:entityId` — entity-specific logs (Admin only)
- `GET /audit/export` — CSV download (Admin only)
- Unit tests covering all filter combinations and CSV export