### PR TITLE
feat(zkp): add per-operation loading indicators to ZkpVaccinationProof

### DIFF
--- a/src/components/ZkpVaccinationProof.tsx
+++ b/src/components/ZkpVaccinationProof.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default function ZkpVaccinationProof({ vaccinationId, vaccineName }: Props) {
-  const { generateProof, verifyProof, loading, error } = useZkp();
+  const { generateProof, verifyProof, isGenerating, isVerifying, error } = useZkp();
   const [proof, setProof] = useState<ZkpProof | null>(null);
   const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
 
@@ -91,18 +91,24 @@ export default function ZkpVaccinationProof({ vaccinationId, vaccineName }: Prop
       <div className="flex gap-2">
         <button
           onClick={handleGenerate}
-          disabled={loading}
-          className="flex-1 py-2 px-3 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+          disabled={isGenerating || isVerifying}
+          className="flex-1 py-2 px-3 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
         >
-          {loading ? 'Generating…' : 'Generate Proof'}
+          {isGenerating && (
+            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          )}
+          {isGenerating ? 'Generating…' : 'Generate Proof'}
         </button>
         {proof && (
           <button
             onClick={handleVerify}
-            disabled={loading}
-            className="flex-1 py-2 px-3 text-sm rounded-lg bg-green-600 hover:bg-green-700 text-white disabled:opacity-50 transition-colors"
+            disabled={isGenerating || isVerifying}
+            className="flex-1 py-2 px-3 text-sm rounded-lg bg-green-600 hover:bg-green-700 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
           >
-            {loading ? 'Verifying…' : 'Verify Proof'}
+            {isVerifying && (
+              <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            )}
+            {isVerifying ? 'Verifying…' : 'Verify Proof'}
           </button>
         )}
       </div>

--- a/src/hooks/useZkp.ts
+++ b/src/hooks/useZkp.ts
@@ -2,12 +2,13 @@ import { useState, useCallback } from 'react';
 import { zkpService, ZkpProof, VerifyResult } from '@/lib/zkp';
 
 export function useZkp() {
-  const [loading, setLoading] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const generateProof = useCallback(
     async (vaccinationId: string, expiresAt?: string): Promise<ZkpProof | null> => {
-      setLoading(true);
+      setIsGenerating(true);
       setError(null);
       try {
         return await zkpService.generateProof(vaccinationId, expiresAt);
@@ -15,14 +16,14 @@ export function useZkp() {
         setError(e instanceof Error ? e.message : 'Failed to generate proof');
         return null;
       } finally {
-        setLoading(false);
+        setIsGenerating(false);
       }
     },
     []
   );
 
   const verifyProof = useCallback(async (proofId: string): Promise<VerifyResult | null> => {
-    setLoading(true);
+    setIsVerifying(true);
     setError(null);
     try {
       return await zkpService.verifyProof(proofId);
@@ -30,9 +31,11 @@ export function useZkp() {
       setError(e instanceof Error ? e.message : 'Failed to verify proof');
       return null;
     } finally {
-      setLoading(false);
+      setIsVerifying(false);
     }
   }, []);
 
-  return { generateProof, verifyProof, loading, error };
+  const loading = isGenerating || isVerifying;
+
+  return { generateProof, verifyProof, isGenerating, isVerifying, loading, error };
 }


### PR DESCRIPTION
closes #590 


- Split useZkp's single loading flag into isGenerating and isVerifying
- Generate/Verify buttons are disabled while either operation is in flight
- Show spinner and updated label text specific to each button's operation
- Preserve backward-compatible loading = isGenerating || isVerifying