### PR TITLE
fix: replace non-null assertion with optional chaining in Sidebar

### DIFF
--- a/src/components/Navigation/Sidebar.tsx
+++ b/src/components/Navigation/Sidebar.tsx
@@ -70,7 +70,7 @@ function SidebarItem({
 
         {expanded && (
           <ul id={`nav-sub-${item.label}`} className="mt-0.5 space-y-0.5">
-            {item.children!.map((child) => (
+            {item.children?.map((child) => (
               <SidebarItem key={child.href} item={child} collapsed={collapsed} depth={depth + 1} />
             ))}
           </ul>


### PR DESCRIPTION
## Summary

`item.children!.map()` on line ~73 of `Sidebar.tsx` throws at runtime if `children` is `undefined`, crashing the entire sidebar.

## Change

```diff
- {item.children!.map((child) => (
+ {item.children?.map((child) => (
```

Optional chaining returns `undefined` (rendered as nothing by React) instead of throwing, so a nav item with no children simply skips the submenu.

No changes to `navConfig.ts` are needed — `children` is already typed as optional (`children?: NavItem[]`), which is correct.

## Acceptance Criteria
- [x] A nav item with `undefined` children no longer crashes the sidebar

Closes #570