### PR TITLE
fix: add admin auth guard to security API routes

### DIFF
--- a/src/lib/api/requireAdmin.ts
+++ b/src/lib/api/requireAdmin.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+/**
+ * Verifies the Bearer token in the request and checks that the user has the
+ * 'admin' role.  Returns the verified user or writes the appropriate error
+ * response (401 / 403) and returns null.
+ */
+export async function requireAdmin(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<{ id: string; role: string } | null> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+
+  const token = authHeader.slice(7);
+
+  let user: { id: string; role: string };
+  try {
+    const response = await fetch(`${BACKEND}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return null;
+    }
+    user = await response.json();
+  } catch {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+
+  if (user.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+
+  return user;
+}

--- a/src/pages/api/security/alerts.ts
+++ b/src/pages/api/security/alerts.ts
@@ -1,11 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { requireAdmin } from '@/lib/api/requireAdmin';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // TODO: Add proper authentication check
-  // const session = await getServerSession(req, res, authOptions);
-  // if (!session || session.user.role !== 'admin') {
-  //   return res.status(401).json({ error: 'Unauthorized' });
-  // }
+  if (!(await requireAdmin(req, res))) return;
 
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });

--- a/src/pages/api/security/alerts/[alertId]/acknowledge.ts
+++ b/src/pages/api/security/alerts/[alertId]/acknowledge.ts
@@ -1,11 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { requireAdmin } from '@/lib/api/requireAdmin';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // TODO: Add proper authentication check
-  // const session = await getServerSession(req, res, authOptions);
-  // if (!session || session.user.role !== 'admin') {
-  //   return res.status(401).json({ error: 'Unauthorized' });
-  // }
+  if (!(await requireAdmin(req, res))) return;
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });

--- a/src/pages/api/security/metrics.ts
+++ b/src/pages/api/security/metrics.ts
@@ -1,11 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { requireAdmin } from '@/lib/api/requireAdmin';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // TODO: Add proper authentication check
-  // const session = await getServerSession(req, res, authOptions);
-  // if (!session || session.user.role !== 'admin') {
-  //   return res.status(401).json({ error: 'Unauthorized' });
-  // }
+  if (!(await requireAdmin(req, res))) return;
 
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });


### PR DESCRIPTION
## Summary

The three security API routes had their auth checks commented out, leaving admin-only endpoints open to any caller. This PR wires up real authentication.

## Changes

**New: `src/lib/api/requireAdmin.ts`**
- Extracts Bearer token from `Authorization` header → 401 if missing
- Verifies token by calling `/auth/me` on the backend → 401 if invalid
- Checks `user.role === 'admin'` → 403 if non-admin
- Returns the verified user on success

**Modified routes** (alerts.ts, metrics.ts, acknowledge.ts)
- Import and call `requireAdmin(req, res)`; return early on failure
- Removed TODO comments and old commented-out auth blocks

## Acceptance Criteria
- [x] Unauthenticated requests receive 401
- [x] Non-admin authenticated requests receive 403
- [x] Admin requests succeed as before

Closes #560