### PR TITLE
fix(#573): Guard null assertion crash risk in MultiSigSetup.tsx

### DIFF
--- a/src/components/Wallet/MultiSigSetup.tsx
+++ b/src/components/Wallet/MultiSigSetup.tsx
@@ -68,11 +68,12 @@ export default function MultiSigSetup({
   }
 
   function validateSigners(): string | null {
+    if (!wallet) return null;
     for (const s of signers) {
       if (!s.publicKey.trim()) return 'All signers must have a public key.';
       if (!s.publicKey.startsWith('G') || s.publicKey.length !== 56)
         return `"${s.publicKey.slice(0, 12)}…" is not a valid Stellar public key (must start with G, 56 chars).`;
-      if (s.publicKey === wallet!.publicKey)
+      if (s.publicKey === wallet.publicKey)
         return "Don't add your own key as a co-signer — adjust the master weight instead.";
       if (s.weight < 0 || s.weight > 255) return 'Signer weight must be between 0 and 255.';
     }


### PR DESCRIPTION
## Summary
- Adds an explicit `if (!wallet) return null` guard at the top of `validateSigners()` so the function is self-contained and safe
- Removes the unsafe `wallet!.publicKey` non-null assertion; `wallet.publicKey` is now used after the guard narrows the type
- The existing early-return at render time already prevents the form rendering when wallet is null; this fix covers the inner validation function as well

## Changes
- `src/components/Wallet/MultiSigSetup.tsx` — added null guard in `validateSigners()`, removed `!` assertion on line ~75

## Test plan
- [ ] Render `MultiSigSetup` with `wallet={null}` — placeholder renders, no crash
- [ ] Render with a valid wallet and attempt to add the wallet's own public key as co-signer — correct validation error fires
- [ ] TypeScript compiler reports no errors on the modified file

Closes #573