### PR TITLE
fix(#574): Remove all any usages from ProfileEditForm.tsx

### DIFF
--- a/src/components/Profile/ProfileEditForm.tsx
+++ b/src/components/Profile/ProfileEditForm.tsx
@@ -3,23 +3,37 @@ import styles from './ProfileEditForm.module.css';
 import { AvatarUpload } from './AvatarUpload';
 import { ProfileCompletion } from './ProfileCompletion';
 
+interface UserProfileData {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  avatarUrl?: string;
+  dateOfBirth?: string;
+  address?: string;
+  city?: string;
+  country?: string;
+}
+
+interface UserProfile extends UserProfileData {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  emailVerified?: boolean;
+  phoneVerified?: boolean;
+  isVerified?: boolean;
+}
+
+interface ProfileCompletionState {
+  completionScore: number;
+  isComplete: boolean;
+  missingFields: string[];
+}
+
 interface ProfileEditFormProps {
-  user?: {
-    id: string;
-    firstName: string;
-    lastName: string;
-    email: string;
-    phone?: string;
-    avatarUrl?: string;
-    emailVerified?: boolean;
-    phoneVerified?: boolean;
-    isVerified?: boolean;
-    dateOfBirth?: string;
-    address?: string;
-    city?: string;
-    country?: string;
-  };
-  onSubmit: (data: any) => Promise<void>;
+  user?: UserProfile;
+  onSubmit: (data: UserProfileData) => Promise<void>;
   onAvatarUpload: (file: File) => Promise<void>;
   isLoading?: boolean;
 }
@@ -45,7 +59,7 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [successMessage, setSuccessMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [profileCompletion, setProfileCompletion] = useState<any>(null);
+  const [profileCompletion, setProfileCompletion] = useState<ProfileCompletionState | null>(null);
 
   useEffect(() => {
     if (user) {
@@ -72,7 +86,7 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
     }
   }, [user]);
 
-  const calculateCompletion = (userData: any) => {
+  const calculateCompletion = (userData: UserProfileData): number => {
     let score = 0;
     const fields = [
       userData.firstName,
@@ -91,7 +105,7 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
     return score;
   };
 
-  const calculateMissingFields = (userData: any) => {
+  const calculateMissingFields = (userData: UserProfileData): string[] => {
     const missing = [];
     if (!userData.firstName) missing.push('firstName');
     if (!userData.lastName) missing.push('lastName');
@@ -180,9 +194,9 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
         missingFields: calculateMissingFields(formData),
       };
       setProfileCompletion(completion);
-    } catch (error: any) {
+    } catch (error: unknown) {
       setErrors({
-        submit: error.message || 'Failed to update profile',
+        submit: error instanceof Error ? error.message : 'Failed to update profile',
       });
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## Summary
- Defines `UserProfileData`, `UserProfile`, and `ProfileCompletionState` interfaces to replace every `any` in the component
- `onSubmit` prop typed `(data: UserProfileData) => Promise<void>` instead of `(data: any)`
- `calculateCompletion` and `calculateMissingFields` helpers typed `(userData: UserProfileData): number / string[]`
- `profileCompletion` state typed `ProfileCompletionState | null` instead of `any`
- `catch (error: any)` narrowed to `catch (error: unknown)` with `instanceof Error` guard

## Changes
- `src/components/Profile/ProfileEditForm.tsx` — 4 `any` usages removed, 3 new interfaces added

## Test plan
- [ ] Profile form loads and pre-populates correctly from `user` prop
- [ ] Submitting the form calls `onSubmit` with the correct typed payload
- [ ] A simulated `onSubmit` rejection still shows the error message in the UI
- [ ] `tsc --noEmit` passes with no errors on the modified file

Closes #574