### PR TITLE
fix(#576): Replace metadata any with discriminated union in NotificationItem

### DIFF
--- a/src/components/Notifications/NotificationItem.tsx
+++ b/src/components/Notifications/NotificationItem.tsx
@@ -12,6 +12,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import styles from './NotificationItem.module.css';
+import type { NotificationMetadata } from '../../types/notification';
 
 const formatTimeAgo = (date: Date): string => {
   const now = new Date();
@@ -32,7 +33,7 @@ export interface NotificationItemProps {
     isRead: boolean;
     createdAt: string;
     actionUrl?: string | null;
-    metadata?: any;
+    metadata?: NotificationMetadata | null;
   };
   onMarkAsRead: (id: string) => void;
   onActionClick?: (url: string) => void;
@@ -97,7 +98,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
         <p className={styles.message}>{message}</p>
 
         {/* Rich Notification: Image Display */}
-        {metadata?.imageUrl && (
+        {metadata && 'imageUrl' in metadata && metadata.imageUrl && (
           <div className={styles.imageContainer}>
             <img src={metadata.imageUrl} alt="Notification attachment" className={styles.image} loading="lazy" width={300} height={200} />
           </div>

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -9,6 +9,79 @@ export type NotificationCategory =
   | 'CONSULTATION'
   | 'SYSTEM';
 
+export interface AppointmentMetadata {
+  type: 'APPOINTMENT';
+  appointmentId?: string;
+  petName?: string;
+  vetName?: string;
+  dateTime?: string;
+}
+
+export interface MedicationMetadata {
+  type: 'MEDICATION';
+  petName?: string;
+  medicationName?: string;
+  dueDate?: string;
+}
+
+export interface VaccinationMetadata {
+  type: 'VACCINATION';
+  petName?: string;
+  vaccineName?: string;
+  dueDate?: string;
+}
+
+export interface AlertMetadata {
+  type: 'ALERT';
+  alertType?: string;
+  petName?: string;
+}
+
+export interface MessageMetadata {
+  type: 'MESSAGE';
+  senderId?: string;
+  senderName?: string;
+  preview?: string;
+}
+
+export interface MedicalRecordMetadata {
+  type: 'MEDICAL_RECORD';
+  petName?: string;
+  recordType?: string;
+  doctorName?: string;
+}
+
+export interface LostPetMetadata {
+  type: 'LOST_PET';
+  petName?: string;
+  petId?: string;
+  imageUrl?: string;
+  lastSeen?: string;
+}
+
+export interface ConsultationMetadata {
+  type: 'CONSULTATION';
+  vetName?: string;
+  petName?: string;
+  scheduledAt?: string;
+}
+
+export interface SystemMetadata {
+  type: 'SYSTEM';
+  imageUrl?: string;
+}
+
+export type NotificationMetadata =
+  | AppointmentMetadata
+  | MedicationMetadata
+  | VaccinationMetadata
+  | AlertMetadata
+  | MessageMetadata
+  | MedicalRecordMetadata
+  | LostPetMetadata
+  | ConsultationMetadata
+  | SystemMetadata;
+
 export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
 
 export interface AppNotification {
@@ -21,7 +94,7 @@ export interface AppNotification {
   isRead: boolean;
   readAt: string | null;
   actionUrl: string | null;
-  metadata: Record<string, unknown> | null;
+  metadata: NotificationMetadata | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Defines 9 per-category metadata interfaces (`AppointmentMetadata`, `MedicationMetadata`, `VaccinationMetadata`, `AlertMetadata`, `MessageMetadata`, `MedicalRecordMetadata`, `LostPetMetadata`, `ConsultationMetadata`, `SystemMetadata`) — each with a `type` discriminant matching `NotificationCategory`
- Exports a `NotificationMetadata` discriminated union from `notification.ts`
- Updates `AppNotification.metadata` from `Record<string, unknown> | null` to `NotificationMetadata | null`
- Updates the `NotificationItemProps` inline type: `metadata?: any` → `metadata?: NotificationMetadata | null`
- Accesses to `imageUrl` in the component now require `'imageUrl' in metadata` narrowing, which TypeScript enforces at compile time — accessing a field not present on the active variant is a type error

## Changes
- `src/types/notification.ts` — 9 metadata interfaces + `NotificationMetadata` union added; `AppNotification.metadata` updated
- `src/components/Notifications/NotificationItem.tsx` — import added, `metadata?: any` replaced, `metadata?.imageUrl` access guarded with `'imageUrl' in metadata`

## Test plan
- [ ] Notifications of all categories render correctly
- [ ] Image attachment renders for `LOST_PET` and `SYSTEM` notifications that include `imageUrl`
- [ ] Attempting to access a field that only exists on one metadata variant without narrowing produces a TS compile error
- [ ] `tsc --noEmit` passes with no errors on both modified files

Closes #576