### PR TITLE
Add visible error handling to ZkpVaccinationProof handlers and Transa…

### DIFF
--- a/src/components/TransactionStatusTracker.tsx
+++ b/src/components/TransactionStatusTracker.tsx
@@ -7,6 +7,7 @@ const MAX_INTERVAL = 160_000;
 export default function TransactionStatusTracker() {
   const [pending, setPending] = useState<Transaction[]>([]);
   const [failed, setFailed] = useState<Transaction[]>([]);
+  const [pollError, setPollError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const delayRef = useRef(BASE_INTERVAL);
 
@@ -23,9 +24,13 @@ export default function TransactionStatusTracker() {
       ]);
       setPending(pendingTxs);
       setFailed(failedTxs);
+      setPollError(null); // clear error on success
       delayRef.current = BASE_INTERVAL; // reset on success
     } catch (error) {
       console.error('Failed to load transaction status:', error);
+      setPollError(
+        error instanceof Error ? error.message : 'Failed to refresh transaction status'
+      );
       delayRef.current = Math.min(delayRef.current * 2, MAX_INTERVAL); // backoff
     }
     scheduleNext(delayRef.current);
@@ -70,12 +75,21 @@ export default function TransactionStatusTracker() {
     }
   };
 
-  if (pending.length === 0 && failed.length === 0) return null;
+  if (pending.length === 0 && failed.length === 0 && !pollError) return null;
 
   return (
     <div className="fixed bottom-4 right-4 w-80 bg-white shadow-lg rounded-lg border">
       <div className="p-4">
         <h3 className="font-semibold mb-3">Transaction Status</h3>
+
+        {pollError && (
+          <div
+            role="alert"
+            className="mb-3 p-2 bg-orange-50 border border-orange-200 rounded text-xs text-orange-700"
+          >
+            Couldn&apos;t refresh transaction status — retrying… ({pollError})
+          </div>
+        )}
 
         {pending.length > 0 && (
           <div className="mb-3">

--- a/src/components/ZkpVaccinationProof.tsx
+++ b/src/components/ZkpVaccinationProof.tsx
@@ -14,20 +14,33 @@ export default function ZkpVaccinationProof({ vaccinationId, vaccineName }: Prop
   const { generateProof, verifyProof, isGenerating, isVerifying, error } = useZkp();
   const [proof, setProof] = useState<ZkpProof | null>(null);
   const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
+  const [handlerError, setHandlerError] = useState<string | null>(null);
 
   const handleGenerate = async () => {
-    const result = await generateProof(vaccinationId);
-    if (result) {
-      setProof(result);
-      setVerifyResult(null);
+    setHandlerError(null);
+    try {
+      const result = await generateProof(vaccinationId);
+      if (result) {
+        setProof(result);
+        setVerifyResult(null);
+      }
+    } catch (e) {
+      setHandlerError(e instanceof Error ? e.message : 'Failed to generate proof');
     }
   };
 
   const handleVerify = async () => {
     if (!proof) return;
-    const result = await verifyProof(proof.id);
-    if (result) setVerifyResult(result);
+    setHandlerError(null);
+    try {
+      const result = await verifyProof(proof.id);
+      if (result) setVerifyResult(result);
+    } catch (e) {
+      setHandlerError(e instanceof Error ? e.message : 'Failed to verify proof');
+    }
   };
+
+  const displayError = handlerError ?? error;
 
   return (
     <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 space-y-4">
@@ -41,9 +54,12 @@ export default function ZkpVaccinationProof({ vaccinationId, vaccineName }: Prop
         medical details.
       </p>
 
-      {error && (
-        <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded p-2">
-          {error}
+      {displayError && (
+        <div
+          role="alert"
+          className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded p-2"
+        >
+          {displayError}
         </div>
       )}
 


### PR DESCRIPTION
Closes #582
Closes #586

Summary
Surfaces failures to the user in two components that previously failed silently.

ZkpVaccinationProof.tsx (#582)
Wrapped both handleGenerate and handleVerify in try/catch.
Added a local handlerError state that captures any error thrown outside the useZkp hook's own handling.
Display logic now falls back through handlerError ?? error (the hook's error field), so any failure — whether caught inside the hook or at the handler level — renders the existing red error banner.
Added role="alert" to the error banner for accessibility.
Acceptance criteria met: a failed proof generation or verification now shows a visible error message instead of failing silently.

TransactionStatusTracker.tsx (#586)
Added a pollError state that is set in the polling catch block and cleared on a successful poll.
Rendered a non-blocking inline banner (orange, role="alert") when a poll fails; the component keeps polling and recovers automatically once a poll succeeds.
Updated the early-return guard so the component still renders the error banner even when there are no pending or failed transactions.
Existing try/catch and exponential backoff (base 10s up to 160s) on the polling loop are preserved, so subsequent polls are not stopped by a transient failure.
Acceptance criteria met: a failed poll shows a non-blocking error indicator and the component keeps retrying on the next interval.

Notes
No changes to the useZkp hook were required — it already exposes an error field, which this component surfaces.
Changes are additive and do not alter existing success-path behavior.