### PR TITLE
I added .catch() to Promise.all Chain in /api/observability/status.ts

### DIFF
--- a/src/pages/api/observability/status.ts
+++ b/src/pages/api/observability/status.ts
@@ -6,10 +6,36 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== 'GET') return res.status(405).end();
   try {
     const [health, alerts, performance] = await Promise.all([
-      fetch(`${BACKEND}/api/v1/observability/health`).then((r) => r.json()),
-      fetch(`${BACKEND}/api/v1/observability/alerts`).then((r) => r.json()),
-      fetch(`${BACKEND}/api/v1/observability/performance`).then((r) => r.json()),
+      fetch(`${BACKEND}/api/v1/observability/health`)
+        .then((r) => {
+          if (!r.ok) throw new Error(`Status ${r.status}`);
+          return r.json();
+        })
+        .catch((err) => ({ status: 'error', error: err.message })),
+      fetch(`${BACKEND}/api/v1/observability/alerts`)
+        .then((r) => {
+          if (!r.ok) throw new Error(`Status ${r.status}`);
+          return r.json();
+        })
+        .catch(() => []),
+      fetch(`${BACKEND}/api/v1/observability/performance`)
+        .then((r) => {
+          if (!r.ok) throw new Error(`Status ${r.status}`);
+          return r.json();
+        })
+        .catch((err) => ({ error: err.message })),
     ]);
+
+    if (health.status === 'error') {
+      return res.status(503).json({
+        error: 'Health check failed',
+        detail: health.error,
+        health,
+        alerts,
+        performance,
+      });
+    }
+
     res.status(200).json({ health, alerts, performance });
   } catch (e) {
     res.status(503).json({ error: 'Backend unreachable', detail: (e as Error).message });


### PR DESCRIPTION
closes #585

This PR resolves issues with the frontend observability status endpoint (/api/observability/status) by implementing robust error handling for each underlying health, alert, and performance check. Previously, the sub-promises within Promise.all did not individually handle network rejections or non-200 responses, causing the status endpoint to return a generic 503 response or reject ungracefully if even a single non-critical endpoint failed.

To address this, we modified the fetching logic to validate response statuses (throwing errors on non-ok responses) and caught rejections locally on each check. This allows non-critical endpoints like alerts and performance monitoring to fail gracefully with fallbacks (empty arrays or structured errors) while permitting the rest of the status payload to load successfully.

Additionally, a structured check was introduced for the core backend health status. If the primary health check fails or returns an error, the endpoint returns a structured 503 error payload containing the available details of all checks, preventing unhandled promise rejections and allowing the frontend client to render degraded states gracefully.