### PR TITLE
fix: guard null authToken before use in surgeryAPI

### DIFF
--- a/src/lib/api/surgeryAPI.test.ts
+++ b/src/lib/api/surgeryAPI.test.ts
@@ -1,0 +1,25 @@
+import { surgeryAPI } from './surgeryAPI';
+
+describe('surgeryAPI auth handling', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('throws a clear error when authToken is missing', async () => {
+    expect.hasAssertions();
+
+    await expect(surgeryAPI.findAll()).rejects.toThrow(
+      'Authentication required. Please log in to continue.'
+    );
+  });
+
+  it('throws a clear error when authToken is null string', async () => {
+    localStorage.setItem('authToken', 'null');
+    expect.hasAssertions();
+
+    await expect(surgeryAPI.findAll()).rejects.toThrow(
+      'Authentication required. Please log in to continue.'
+    );
+  });
+});

--- a/src/lib/api/surgeryAPI.ts
+++ b/src/lib/api/surgeryAPI.ts
@@ -65,9 +65,14 @@ class SurgeryAPI {
 
     this.api.interceptors.request.use((config) => {
       const token = localStorage.getItem('authToken');
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+      if (!token || token.trim() === '' || token === 'null') {
+        throw new Error('Authentication required. Please log in to continue.');
       }
+
+      config.headers = {
+        ...config.headers,
+        Authorization: `Bearer ${token}`,
+      };
       return config;
     });
   }


### PR DESCRIPTION
## fix(surgeryAPI): fail fast when authToken is missing or invalid

## PR Description

- Fix surgeryAPI.ts so the Axios request interceptor checks `localStorage.getItem('authToken')` before adding `Authorization`.
- If `authToken` is missing, empty, or the literal string `"null"`, the request now throws:
  - `Authentication required. Please log in to continue.`
- This prevents malformed requests from sending `Authorization: Bearer null` to the backend.

## Files changed

- surgeryAPI.ts
- surgeryAPI.test.ts

Closes: #588