### PR TITLE
fix: useSwipe isSwiping state, labResultsAPI client, transactions page wired

### DIFF
--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useState } from 'react';
 
 export interface SwipeHandlers {
   onSwipeLeft?: () => void;
@@ -30,14 +30,17 @@ export function useSwipe(options: SwipeOptions = {}) {
     onSwipeDown,
   } = options;
   const start = useRef<TouchPoint | null>(null);
+  const [isSwiping, setIsSwiping] = useState(false);
 
   const onTouchStart = useCallback((e: React.TouchEvent) => {
     const t = e.touches[0];
     start.current = { x: t.clientX, y: t.clientY, t: Date.now() };
+    setIsSwiping(true);
   }, []);
 
   const onTouchEnd = useCallback(
     (e: React.TouchEvent) => {
+      setIsSwiping(false);
       if (!start.current) return;
       const t = e.changedTouches[0];
       const dx = t.clientX - start.current.x;
@@ -59,5 +62,5 @@ export function useSwipe(options: SwipeOptions = {}) {
     [threshold, timeout, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown]
   );
 
-  return { onTouchStart, onTouchEnd };
+  return { onTouchStart, onTouchEnd, isSwiping };
 }

--- a/src/lib/api/labResultsAPI.ts
+++ b/src/lib/api/labResultsAPI.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import { getApiBaseUrl } from './apiBaseUrl';
+import { LabResultItem, LabReport } from '@/types/lab-results';
+
+function client() {
+  return axios.create({ baseURL: getApiBaseUrl() });
+}
+
+export async function getLabResults(petId: string): Promise<LabResultItem[]> {
+  const { data } = await client().get<LabResultItem[]>(`/pets/${petId}/lab-results`);
+  return data;
+}
+
+export async function getLabReport(reportId: string): Promise<LabReport> {
+  const { data } = await client().get<LabReport>(`/lab-reports/${reportId}`);
+  return data;
+}
+
+export async function uploadLabReport(petId: string, file: File, meta?: Partial<LabReport>): Promise<LabReport> {
+  const form = new FormData();
+  form.append('file', file);
+  if (meta) form.append('meta', JSON.stringify(meta));
+  const { data } = await client().post<LabReport>(`/pets/${petId}/lab-reports`, form);
+  return data;
+}
+
+export async function deleteLabReport(reportId: string): Promise<void> {
+  await client().delete(`/lab-reports/${reportId}`);
+}


### PR DESCRIPTION
## Summary

- **#533 (useSwipe)** — Added `isSwiping` state: `true` when a touch gesture starts, `false` on `touchend`. The swipe direction callbacks and threshold logic were already implemented; only the `isSwiping` flag was missing from the returned object.
- **#535 (Lab Results)** — Created `src/lib/api/labResultsAPI.ts` following the established axios pattern (`getLabResults`, `getLabReport`, `uploadLabReport`, `deleteLabReport`). The page and `ResultsDashboard` component were already fully implemented with loading/error states.
- **#536 (Transactions)** — Page was already fully implemented (`TransactionHistory`, `TransactionDetails`, `TransactionStatusTracker`, `TransactionCostTracker` all wired up). No changes needed.

## Files changed

- `src/hooks/useSwipe.ts` — adds `isSwiping` useState, sets it on touchstart/touchend
- `src/lib/api/labResultsAPI.ts` — new file, axios-based lab results API client

Closes #533
Closes #535
Closes #536