### PR TITLE
Fix/polling timeout interval leak tsnocheck logging

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenException,
   HttpException,
   HttpStatus,
+  Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -75,6 +76,8 @@ export interface VerificationStatusResponse {
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
@@ -150,7 +153,7 @@ export class AuthService {
       );
     } catch (error) {
       // Log error but don't fail registration
-      console.error('Failed to send verification email:', error);
+      this.logger.error('Failed to send verification email:', error);
     }
 
     await this.sendPhoneVerificationCode(savedUser, phoneVerificationCode);
@@ -448,7 +451,7 @@ export class AuthService {
         verificationToken,
       );
     } catch (error) {
-      console.error('Failed to resend verification email:', error);
+      this.logger.error('Failed to resend verification email:', error);
     }
   }
 
@@ -709,7 +712,7 @@ export class AuthService {
     );
 
     if (!result.success) {
-      console.error('Failed to send verification SMS:', result.error);
+      this.logger.error('Failed to send verification SMS:', result.error);
     }
   }
 

--- a/backend/src/auth/services/email.service.ts
+++ b/backend/src/auth/services/email.service.ts
@@ -1,26 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { EmailService } from '../interfaces/email-service.interface';
 
 @Injectable()
 export class EmailServiceImpl implements EmailService {
+  private readonly logger = new Logger(EmailServiceImpl.name);
+
   async sendVerificationEmail(email: string, token: string): Promise<void> {
-    // TODO: Implement email sending logic
-    // This is a placeholder implementation
-    console.log(
+    this.logger.log(
       `Verification email would be sent to ${email} with token: ${token}`,
     );
-    console.log(
+    this.logger.log(
       `Verification link: http://localhost:3000/verify-email?token=${token}`,
     );
   }
 
   async sendPasswordResetEmail(email: string, token: string): Promise<void> {
-    // TODO: Implement email sending logic
-    // This is a placeholder implementation
-    console.log(
+    this.logger.log(
       `Password reset email would be sent to ${email} with token: ${token}`,
     );
-    console.log(
+    this.logger.log(
       `Reset link: http://localhost:3000/reset-password?token=${token}`,
     );
   }

--- a/backend/src/modules/blockchain/blockchain-sync.service.ts
+++ b/backend/src/modules/blockchain/blockchain-sync.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';

--- a/backend/src/modules/blockchain/contract-interaction.service.ts
+++ b/backend/src/modules/blockchain/contract-interaction.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Injectable, Logger } from '@nestjs/common';
 import { StellarService } from './stellar.service';
 import { ContractManagementService } from './contract-management.service';

--- a/backend/src/modules/blockchain/contract-management.service.ts
+++ b/backend/src/modules/blockchain/contract-management.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Injectable, Logger } from '@nestjs/common';
 import { StellarService } from './stellar.service';
 import { InjectRepository } from '@nestjs/typeorm';

--- a/backend/src/modules/blockchain/hash-anchoring.service.ts
+++ b/backend/src/modules/blockchain/hash-anchoring.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';

--- a/backend/src/modules/blockchain/payment-automation.service.ts
+++ b/backend/src/modules/blockchain/payment-automation.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Injectable, Logger } from '@nestjs/common';
 import { StellarService } from './stellar.service';
 import { ContractManagementService } from './contract-management.service';

--- a/backend/src/modules/blockchain/stellar.service.ts
+++ b/backend/src/modules/blockchain/stellar.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
@@ -208,8 +207,15 @@ export class StellarService implements OnModuleInit {
       if (response.status === 'ERROR')
         throw new Error(`Transaction failed: ${response.errorResult}`);
 
+      const maxPollingAttempts = 30;
+      let attempts = 0;
       let result = await this.sorobanServer.getTransaction(response.hash);
       while (result.status === 'NOT_FOUND') {
+        if (++attempts >= maxPollingAttempts) {
+          throw new Error(
+            `Transaction ${response.hash} did not finalize after ${maxPollingAttempts} polling attempts`,
+          );
+        }
         await new Promise((resolve) => setTimeout(resolve, 1000));
         result = await this.sorobanServer.getTransaction(response.hash);
       }

--- a/backend/src/modules/email/email.service.ts
+++ b/backend/src/modules/email/email.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThanOrEqual, In } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
@@ -22,7 +22,7 @@ import {
 import { baseTemplate, emailButton } from './templates/base.template';
 
 @Injectable()
-export class EmailService implements OnModuleInit {
+export class EmailService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(EmailService.name);
   private processorInterval: NodeJS.Timeout | null = null;
 
@@ -57,6 +57,13 @@ export class EmailService implements OnModuleInit {
     this.logger.log(
       `Email queue processor started (every ${intervalMs / 1000}s)`,
     );
+  }
+
+  onModuleDestroy() {
+    if (this.processorInterval) {
+      clearInterval(this.processorInterval);
+      this.processorInterval = null;
+    }
   }
 
   // ── Public API ─────────────────────────────────────────────────────────────

--- a/backend/src/modules/medical-records/medical-records.controller.ts
+++ b/backend/src/modules/medical-records/medical-records.controller.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Controller,
   Get,

--- a/backend/src/modules/stellar-wallet-management/stellar-wallet-management.service.ts
+++ b/backend/src/modules/stellar-wallet-management/stellar-wallet-management.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   BadRequestException,
   Inject,

--- a/backend/src/modules/users/services/file-upload.service.ts
+++ b/backend/src/modules/users/services/file-upload.service.ts
@@ -94,7 +94,7 @@ export class FileUploadService {
       }
     } catch (error) {
       // Log error but don't throw - file may already be deleted
-      console.error(`Failed to delete avatar: ${error}`);
+      this.logger.error(`Failed to delete avatar: ${error}`);
     }
   }
 

--- a/backend/src/modules/wallets/wallets.service.ts
+++ b/backend/src/modules/wallets/wallets.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   BadRequestException,
   Inject,


### PR DESCRIPTION


closes #671 
closes #672 
closes #673 
closes #674

---
FILES CHANGED:

- backend/src/modules/blockchain/stellar.service.ts
- backend/src/modules/email/email.service.ts
- backend/src/modules/medical-records/medical-records.controller.ts
- backend/src/modules/blockchain/blockchain-sync.service.ts
- backend/src/modules/blockchain/hash-anchoring.service.ts
- backend/src/modules/blockchain/contract-management.service.ts
- backend/src/modules/blockchain/contract-interaction.service.ts
- backend/src/modules/blockchain/payment-automation.service.ts
- backend/src/modules/stellar-wallet-management/stellar-wallet-management.service.ts
- backend/src/auth/auth.service.ts
- backend/src/auth/services/email.service.ts
- backend/src/modules/users/services/file-upload.service.ts

---
What was fixed:

1. Soroban polling loop timeout (stellar.service.ts:210-221) — Added maxPollingAttempts = 30 counter; throws a descriptive error after 30 attempts (~30 seconds) instead of looping forever.
2. Email interval leak (email.service.ts) — Added OnModuleDestroy interface and onModuleDestroy() method that calls clearInterval(this.processorInterval), preventing dangling timers on teardown/hot-reload.
3. @ts-nocheck removal — Removed the directive from medical-records.controller.ts and all 7 blockchain/wallet/stellar-wallet-management service files, restoring TypeScript type checking to these high-risk modules. (Note: wallets.service.ts is gitignored and couldn't be committed, but the directive was removed locally.)
4. console.* → Logger — Replaced all raw console.error/console.log calls in auth.service.ts (3 occurrences), auth/services/email.service.ts (4 occurrences), and file-upload.service.ts (1 occurrence) with NestJS Logger instances, routing output through the structured logging pipeline.
