### PR TITLE
Fix/security and correctness issues

### DIFF
--- a/backend/src/modules/prescriptions/prescriptions.controller.ts
+++ b/backend/src/modules/prescriptions/prescriptions.controller.ts
@@ -58,6 +58,7 @@ export class PrescriptionsController {
   @Get('pet/:petId/expiring-soon')
   getExpiringSoon(@Param('petId') petId: string, @Query('days') days?: number) {
     return this.prescriptionsService.getExpiringPrescriptions(
+      petId,
       days ? +days : 30,
     );
   }

--- a/backend/src/modules/prescriptions/prescriptions.service.ts
+++ b/backend/src/modules/prescriptions/prescriptions.service.ts
@@ -388,6 +388,7 @@ export class PrescriptionsService {
    * Get prescriptions expiring soon
    */
   async getExpiringPrescriptions(
+    petId: string,
     daysWindow: number = 30,
   ): Promise<Prescription[]> {
     const today = new Date();
@@ -396,6 +397,7 @@ export class PrescriptionsService {
 
     return await this.prescriptionRepository.find({
       where: {
+        petId,
         status: PrescriptionStatus.ACTIVE,
         endDate: Between(today, windowEnd),
       },

--- a/backend/src/modules/wallets/wallets.service.ts
+++ b/backend/src/modules/wallets/wallets.service.ts
@@ -198,6 +198,12 @@ export class WalletsService {
   }> {
     const wallet = await this.findOneForUser(walletId, userId);
 
+    if (dto.network !== wallet.network) {
+      throw new BadRequestException(
+        `Network mismatch: request specifies '${dto.network}' but wallet is configured for '${wallet.network}'`,
+      );
+    }
+
     const network = this.stellarCfg.networks[dto.network];
     const horizonUrl = dto.horizonUrl || network.horizonUrl;
 

--- a/backend/src/modules/zkp/zkp.service.ts
+++ b/backend/src/modules/zkp/zkp.service.ts
@@ -136,7 +136,13 @@ export class ZkpService {
     publicInputs: Record<string, unknown>,
     privateWitness: Record<string, unknown>,
   ): { proof: string; commitment: string } {
-    const secret = process.env.ZKP_SECRET ?? 'zkp-dev-secret';
+    const secret = process.env.ZKP_SECRET;
+    if (!secret) {
+      throw new Error(
+        'ZKP_SECRET environment variable is not configured. ' +
+          'Set ZKP_SECRET to a strong random value before starting the application.',
+      );
+    }
     const commitment = crypto
       .createHmac('sha256', secret)
       .update(JSON.stringify(privateWitness))


### PR DESCRIPTION
closes #663 
closes #664 
closes #665 
closes #666


FILES CHANGED:
- backend/src/modules/zkp/zkp.service.ts
- backend/src/modules/wallets/wallets.service.ts
- backend/src/modules/prescriptions/prescriptions.controller.ts
- backend/src/modules/prescriptions/prescriptions.service.ts

---
Issue 1 — ZKP hardcoded secret fallback (zkp.service.ts:139)
Removed the ?? 'zkp-dev-secret' fallback. _simulateProof now reads process.env.ZKP_SECRET and throws a descriptive Error if the variable is absent, forcing the app to fail fast at runtime rather than silently using a known-weak secret.

Issue 2 — Wallet network mismatch not validated (wallets.service.ts:201)
Added an explicit guard at the top of prepareTransaction that compares dto.network against wallet.network (stored on the entity). A BadRequestException is thrown with a clear message when they differ, preventing cross-network transaction construction.

Issue 3 — petId not forwarded to expiring-prescriptions query (prescriptions.controller.ts:58-63)
The controller now passes petId as the first argument to getExpiringPrescriptions. The service signature was updated to getExpiringPrescriptions(petId: string, daysWindow = 30) and petId is included in the TypeORM where clause, scoping results to the requested pet.

Issue 4 — Duplicate getRefillReminders (prescriptions.service.ts:267/481)
Inspected the live file — only one implementation exists at line 267 (line 481 is the class closing brace). The single remaining implementation is the complete, correct one that calculates daysUntilRefill per prescription and sorts results. No action needed beyond confirming the duplicate is already gone.