### PR TITLE
feat: add fr-CA, pt-BR, sw locale support with i18next integration an…

### DIFF
--- a/wata-board-frontend/src/components/ResponsiveNavigation.tsx
+++ b/wata-board-frontend/src/components/ResponsiveNavigation.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation } from 'react-router-dom';
 import { NetworkSwitcher } from './NetworkSwitcher';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import MobileNavigation from './MobileNavigation';
-import { LanguageSwitcher } from './LanguageSwitcher';
 import { announceToScreenReader, trapFocus, generateId, getAriaLabel } from '../utils/accessibility';
 
 export const ResponsiveNavigation: React.FC = () => {

--- a/wata-board-frontend/src/i18n/index.ts
+++ b/wata-board-frontend/src/i18n/index.ts
@@ -13,6 +13,9 @@ import hi from './locales/hi.json';
 import pt from './locales/pt.json';
 import ru from './locales/ru.json';
 import ja from './locales/ja.json';
+import frCA from './locales/fr-CA.json';
+import ptBR from './locales/pt-BR.json';
+import sw from './locales/sw.json';
 
 // Supported languages configuration
 export const supportedLanguages = [
@@ -25,7 +28,10 @@ export const supportedLanguages = [
   { code: 'hi', name: 'Hindi', nativeName: 'हिन्दी', dir: 'ltr', flag: '🇮🇳' },
   { code: 'pt', name: 'Portuguese', nativeName: 'Português', dir: 'ltr', flag: '🇧🇷' },
   { code: 'ru', name: 'Russian', nativeName: 'Русский', dir: 'ltr', flag: '🇷🇺' },
-  { code: 'ja', name: 'Japanese', nativeName: '日本語', dir: 'ltr', flag: '🇯🇵' }
+  { code: 'ja', name: 'Japanese', nativeName: '日本語', dir: 'ltr', flag: '🇯🇵' },
+  { code: 'fr-CA', name: 'French (Canada)', nativeName: 'Français (Canada)', dir: 'ltr', flag: '🇨🇦' },
+  { code: 'pt-BR', name: 'Portuguese (Brazil)', nativeName: 'Português (Brasil)', dir: 'ltr', flag: '🇧🇷' },
+  { code: 'sw', name: 'Swahili', nativeName: 'Kiswahili', dir: 'ltr', flag: '🇰🇪' }
 ] as const;
 
 // Resources object with all translations
@@ -39,7 +45,10 @@ const resources = {
   hi: { translation: hi },
   pt: { translation: pt },
   ru: { translation: ru },
-  ja: { translation: ja }
+  ja: { translation: ja },
+  'fr-CA': { translation: frCA },
+  'pt-BR': { translation: ptBR },
+  sw: { translation: sw }
 };
 
 // Default language
@@ -87,11 +96,11 @@ const defaultLanguage = 'en';
     // Whitelist of supported languages
     supportedLngs: supportedLanguages.map(lang => lang.code),
     
-    // Load configuration
-    load: 'languageOnly',
+    // Load configuration (use 'all' so region-specific locales like fr-CA, pt-BR are respected)
+    load: 'all',
     
     // Preload languages for better performance
-    preload: ['en', 'es', 'fr', 'de', 'zh']
+    preload: ['en', 'es', 'fr', 'de', 'zh', 'fr-CA', 'pt-BR', 'sw']
   });
 
 // Export i18n instance and utilities
@@ -147,16 +156,23 @@ const initializeDocumentLanguage = () => {
 initializeDocumentLanguage();
 i18n.on('languageChanged', initializeDocumentLanguage);
 
+// Map i18n language codes to Intl locale identifiers for broader compatibility
+const toIntlLocale = (lang: string): string => {
+  const map: Record<string, string> = {
+    zh: 'zh-CN',
+    sw: 'sw-TZ',
+  };
+  return map[lang] || lang;
+};
+
 // Helper function to format numbers with locale
 export const formatNumber = (number: number, options?: Intl.NumberFormatOptions) => {
-  const locale = i18n.language === 'zh' ? 'zh-CN' : i18n.language;
-  return new Intl.NumberFormat(locale, options).format(number);
+  return new Intl.NumberFormat(toIntlLocale(i18n.language), options).format(number);
 };
 
 // Helper function to format currency
 export const formatCurrency = (amount: number, currency = 'XLM') => {
-  const locale = i18n.language === 'zh' ? 'zh-CN' : i18n.language;
-  return new Intl.NumberFormat(locale, {
+  return new Intl.NumberFormat(toIntlLocale(i18n.language), {
     style: 'currency',
     currency: currency,
     minimumFractionDigits: 7,
@@ -166,8 +182,7 @@ export const formatCurrency = (amount: number, currency = 'XLM') => {
 
 // Helper function to format dates
 export const formatDate = (date: Date, options?: Intl.DateTimeFormatOptions) => {
-  const locale = i18n.language === 'zh' ? 'zh-CN' : i18n.language;
-  return new Intl.DateTimeFormat(locale, options).format(date);
+  return new Intl.DateTimeFormat(toIntlLocale(i18n.language), options).format(date);
 };
 
 // Helper function to get plural form

--- a/wata-board-frontend/src/i18n/locales/fr-CA.json
+++ b/wata-board-frontend/src/i18n/locales/fr-CA.json
@@ -1,0 +1,267 @@
+{
+  "app": {
+    "title": "Wata-Board",
+    "tagline": "Paiements de services publics décentralisés sur la blockchain Stellar",
+    "description": "Payez vos factures de services publics en utilisant la cryptomonnaie sur le réseau Stellar",
+    "footer": {
+      "tagline": "Solutions de paiement modernes pour le web décentralisé"
+    }
+  },
+  "navigation": {
+    "home": "Payer Facture",
+    "about": "À Propos",
+    "contact": "Contact",
+    "rate": "Évaluez-nous",
+    "language": "Langue"
+  },
+  "payment": {
+    "form": {
+      "title": "Informations de Paiement",
+      "meterNumber": "Numéro de compteur",
+      "meterPlaceholder": "ex. COMPTEUR-123",
+      "meterDescription": "Entrez votre numéro de compteur de services comme indiqué sur votre facture",
+      "amount": "Montant",
+      "amountPlaceholder": "Nombre entier",
+      "amountDescription": "Entrez le montant du paiement en XLM entier",
+      "payButton": "Payer facture",
+      "processing": "Traitement en cours...",
+      "rateLimited": "Limite de débit atteinte",
+      "requiresExtension": "Nécessite l'extension Freighter. Limite de 5 transactions par minute."
+    },
+    "status": {
+      "title": "Statut",
+      "ready": "Prêt.",
+      "installWallet": "Veuillez installer l'extension Freighter Wallet!",
+      "enterMeter": "Veuillez entrer un numéro de compteur.",
+      "enterValidAmount": "Veuillez entrer un montant valide supérieur à 0.",
+      "wholeNumber": "Le montant doit être un nombre entier.",
+      "amountTooLarge": "Le montant est trop élevé.",
+      "insufficientBalance": "Solde insuffisant. Veuillez ajouter plus de XLM à votre portefeuille.",
+      "estimatingFees": "Estimation des frais de transaction... Veuillez patienter.",
+      "estimationFailed": "Impossible d'estimer les frais de transaction. Veuillez réessayer.",
+      "paymentSuccess": "Paiement réussi! ID de transaction : {{id}}...",
+      "paymentFailed": "Paiement échoué : {{error}}"
+    },
+    "feeEstimation": {
+      "title": "Estimation des Frais de Transaction",
+      "calculating": "(Calcul en cours...)",
+      "calculatingFees": "Calcul des frais estimés...",
+      "paymentAmount": "Montant du Paiement",
+      "estimatedNetworkFee": "Frais de Réseau Estimés",
+      "totalCost": "Coût Total",
+      "unableToEstimate": "Impossible d'estimer les frais pour le moment"
+    },
+    "rateLimit": {
+      "title": "Statut de Limite de Débit",
+      "requestsAvailable": "{{count}}/5 requêtes disponibles",
+      "rateLimited": "Limite atteinte. Réinitialisation dans {{time}}",
+      "queue": "File d'attente : {{count}}"
+    }
+  },
+  "wallet": {
+    "balance": {
+      "title": "Solde du Portefeuille",
+      "available": "Solde Disponible",
+      "total": "Solde Total",
+      "loading": "Chargement du solde...",
+      "error": "Échec du chargement du solde",
+      "reconnect": "Veuillez reconnecter votre portefeuille",
+      "insufficient": "Solde insuffisant pour cette transaction",
+      "lowBalance": "Avertissement de solde faible"
+    },
+    "connection": {
+      "connected": "Connecté",
+      "disconnected": "Déconnecté",
+      "connecting": "Connexion en cours...",
+      "connectWallet": "Connecter le Portefeuille",
+      "switchWallet": "Changer de Portefeuille"
+    }
+  },
+  "network": {
+    "mainnet": "RÉSEAU PRINCIPAL",
+    "testnet": "RÉSEAU DE TEST",
+    "switchNetwork": "Changer de Réseau",
+    "currentNetwork": "Réseau Actuel",
+    "switchTo": "Passer à {{network}}?",
+    "mainnetWarning": "Avertissement : Ceci est un réseau de production. Des fonds réels seront utilisés.",
+    "testnetInfo": "Vous passez au réseau de test Stellar. Les transactions utiliseront des XLM de test.",
+    "mainnetConfirm": "Vous êtes sur le point de passer au réseau principal Stellar. Les transactions utiliseront de vrais XLM.",
+    "cancel": "Annuler",
+    "confirm": "Confirmer"
+  },
+  "offline": {
+    "banner": {
+      "title": "Vous êtes hors ligne",
+      "description": "Certaines fonctionnalités peuvent ne pas être disponibles. Les actions seront mises en file d'attente et traitées lorsque vous serez de nouveau en ligne.",
+      "retry": "Réessayer la Connexion",
+      "details": "Détails de la Connexion"
+    },
+    "status": {
+      "online": "En ligne",
+      "offline": "Hors ligne",
+      "connecting": "Connexion en cours...",
+      "queueStatus": "{{count}} action en file d'attente",
+      "queueStatus_plural": "{{count}} actions en file d'attente"
+    },
+    "queue": {
+      "title": "File d'Attente Hors Ligne",
+      "description": "{{count}} action sera traitée lorsque vous serez de nouveau en ligne",
+      "description_plural": "{{count}} actions seront traitées lorsque vous serez de nouveau en ligne"
+    },
+    "error": {
+      "paymentOffline": "Paiement mis en file d'attente pour lorsque vous serez de nouveau en ligne",
+      "generalOffline": "Action mise en file d'attente pour lorsque vous serez de nouveau en ligne"
+    }
+  },
+  "about": {
+    "title": "À Propos de Wata-Board",
+    "description": "Wata-Board est une plateforme de paiement de services publics décentralisée construite sur la blockchain Stellar. Nous permettons des paiements de factures de services sécurisés, transparents et efficaces en utilisant la cryptomonnaie.",
+    "features": {
+      "title": "Caractéristiques Clés",
+      "secure": "Transactions Sécurisées",
+      "secureDescription": "Construit sur la blockchain Stellar avec une sécurité de niveau entreprise",
+      "fast": "Paiements Rapides",
+      "fastDescription": "Règlement quasi instantané avec des frais de transaction peu élevés",
+      "transparent": "Registres Transparents",
+      "transparentDescription": "Toutes les transactions sont enregistrées sur la blockchain publique",
+      "decentralized": "Décentralisé",
+      "decentralizedDescription": "Aucun point de défaillance ou de contrôle unique"
+    },
+    "howItWorks": {
+      "title": "Comment Ça Marche",
+      "step1": "Connectez votre portefeuille",
+      "step2": "Entrez les détails du compteur",
+      "step3": "Confirmez le paiement",
+      "step4": "Paiement traité"
+    }
+  },
+  "contact": {
+    "title": "Contactez-nous",
+    "description": "Communiquez avec notre équipe pour du soutien, des questions ou des commentaires.",
+    "form": {
+      "name": "Nom",
+      "namePlaceholder": "Entrez votre nom",
+      "email": "Courriel",
+      "emailPlaceholder": "Entrez votre courriel",
+      "subject": "Sujet",
+      "subjectPlaceholder": "Entrez le sujet",
+      "message": "Message",
+      "messagePlaceholder": "Entrez votre message",
+      "sendButton": "Envoyer le Message",
+      "sending": "Envoi en cours..."
+    },
+    "info": {
+      "email": "Courriel",
+      "support": "Soutien",
+      "website": "Site web"
+    }
+  },
+  "rate": {
+    "title": "Évaluez Votre Expérience",
+    "description": "Aidez-nous à nous améliorer en évaluant votre expérience avec Wata-Board.",
+    "rating": {
+      "excellent": "Excellent",
+      "good": "Bon",
+      "average": "Moyen",
+      "poor": "Mauvais",
+      "terrible": "Terrible"
+    },
+    "review": {
+      "title": "Écrire un Commentaire",
+      "placeholder": "Partagez votre expérience avec Wata-Board...",
+      "submit": "Soumettre le Commentaire",
+      "thankYou": "Merci pour vos commentaires!"
+    }
+  },
+  "errors": {
+    "general": {
+      "title": "Erreur",
+      "unknown": "Une erreur inconnue s'est produite",
+      "tryAgain": "Veuillez réessayer",
+      "contactSupport": "Contactez le soutien si le problème persiste"
+    },
+    "network": {
+      "title": "Erreur de Réseau",
+      "description": "Impossible de se connecter au réseau",
+      "checkConnection": "Veuillez vérifier votre connexion internet"
+    },
+    "wallet": {
+      "title": "Erreur de Portefeuille",
+      "notConnected": "Portefeuille non connecté",
+      "notInstalled": "Portefeuille Freighter non installé",
+      "installFreighter": "Veuillez installer l'extension de portefeuille Freighter"
+    }
+  },
+  "accessibility": {
+    "skipToMain": "Passer au contenu principal",
+    "skipToNavigation": "Passer à la navigation",
+    "menuToggle": "Basculer le menu de navigation",
+    "closeMenu": "Fermer le menu",
+    "openMenu": "Ouvrir le menu",
+    "loading": "Chargement en cours...",
+    "error": "Erreur",
+    "success": "Succès",
+    "warning": "Avertissement",
+    "info": "Information"
+  },
+  "common": {
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "save": "Sauvegarder",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "back": "Retour",
+    "next": "Suivant",
+    "previous": "Précédent",
+    "submit": "Soumettre",
+    "reset": "Réinitialiser",
+    "clear": "Effacer",
+    "search": "Rechercher",
+    "filter": "Filtrer",
+    "sort": "Trier",
+    "loading": "Chargement en cours...",
+    "error": "Erreur",
+    "success": "Succès",
+    "retry": "Réessayer",
+    "refresh": "Actualiser",
+    "copy": "Copier",
+    "copied": "Copié!",
+    "learnMore": "En Savoir Plus",
+    "viewDetails": "Voir les Détails",
+    "hideDetails": "Masquer les Détails"
+  },
+  "time": {
+    "seconds": "seconde",
+    "seconds_plural": "secondes",
+    "minutes": "minute",
+    "minutes_plural": "minutes",
+    "hours": "heure",
+    "hours_plural": "heures",
+    "days": "jour",
+    "days_plural": "jours",
+    "weeks": "semaine",
+    "weeks_plural": "semaines",
+    "months": "mois",
+    "months_plural": "mois",
+    "years": "an",
+    "years_plural": "ans",
+    "ago": "il y a {{time}}",
+    "in": "dans {{time}}"
+  },
+  "currency": {
+    "xlm": "XLM",
+    "usd": "$ US",
+    "eur": "€"
+  },
+  "validation": {
+    "required": "Ce champ est requis",
+    "invalid": "Format invalide",
+    "tooShort": "Doit contenir au moins {{min}} caractères",
+    "tooLong": "Ne doit pas dépasser {{max}} caractères",
+    "invalidEmail": "Veuillez entrer une adresse courriel valide",
+    "invalidNumber": "Veuillez entrer un nombre valide",
+    "minValue": "Doit être au moins {{min}}",
+    "maxValue": "Ne doit pas dépasser {{max}}"
+  }
+}

--- a/wata-board-frontend/src/i18n/locales/pt-BR.json
+++ b/wata-board-frontend/src/i18n/locales/pt-BR.json
@@ -1,0 +1,267 @@
+{
+  "app": {
+    "title": "Wata-Board",
+    "tagline": "Pagamentos de serviços públicos descentralizados na blockchain Stellar",
+    "description": "Pague suas contas de serviços públicos usando criptomoeda na rede Stellar",
+    "footer": {
+      "tagline": "Soluções de pagamento modernas para a web descentralizada"
+    }
+  },
+  "navigation": {
+    "home": "Pagar Conta",
+    "about": "Sobre",
+    "contact": "Contato",
+    "rate": "Avalie-nos",
+    "language": "Idioma"
+  },
+  "payment": {
+    "form": {
+      "title": "Informações de Pagamento",
+      "meterNumber": "Número do medidor",
+      "meterPlaceholder": "ex.: MEDIDOR-123",
+      "meterDescription": "Insira o número do seu medidor de serviços conforme exibido na sua conta",
+      "amount": "Valor",
+      "amountPlaceholder": "Número inteiro",
+      "amountDescription": "Insira o valor do pagamento em XLM inteiro",
+      "payButton": "Pagar conta",
+      "processing": "Processando...",
+      "rateLimited": "Limite de requisições atingido",
+      "requiresExtension": "Requer a extensão Freighter. Limite de 5 transações por minuto."
+    },
+    "status": {
+      "title": "Status",
+      "ready": "Pronto.",
+      "installWallet": "Por favor, instale a extensão Freighter Wallet!",
+      "enterMeter": "Por favor, insira um número de medidor.",
+      "enterValidAmount": "Por favor, insira um valor válido maior que 0.",
+      "wholeNumber": "O valor deve ser um número inteiro.",
+      "amountTooLarge": "O valor é muito grande.",
+      "insufficientBalance": "Saldo insuficiente. Por favor, adicione mais XLM à sua carteira.",
+      "estimatingFees": "Estimando taxas de transação... Por favor, aguarde.",
+      "estimationFailed": "Não foi possível estimar as taxas de transação. Por favor, tente novamente.",
+      "paymentSuccess": "Pagamento realizado com sucesso! ID da transação: {{id}}...",
+      "paymentFailed": "Falha no pagamento: {{error}}"
+    },
+    "feeEstimation": {
+      "title": "Estimativa de Taxa de Transação",
+      "calculating": "(Calculando...)",
+      "calculatingFees": "Calculando taxas estimadas...",
+      "paymentAmount": "Valor do Pagamento",
+      "estimatedNetworkFee": "Taxa de Rede Estimada",
+      "totalCost": "Custo Total",
+      "unableToEstimate": "Não foi possível estimar as taxas no momento"
+    },
+    "rateLimit": {
+      "title": "Status do Limite de Requisições",
+      "requestsAvailable": "{{count}}/5 requisições disponíveis",
+      "rateLimited": "Limite atingido. Reinicia em {{time}}",
+      "queue": "Fila: {{count}}"
+    }
+  },
+  "wallet": {
+    "balance": {
+      "title": "Saldo da Carteira",
+      "available": "Saldo Disponível",
+      "total": "Saldo Total",
+      "loading": "Carregando saldo...",
+      "error": "Falha ao carregar saldo",
+      "reconnect": "Por favor, reconecte sua carteira",
+      "insufficient": "Saldo insuficiente para esta transação",
+      "lowBalance": "Aviso de saldo baixo"
+    },
+    "connection": {
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "connecting": "Conectando...",
+      "connectWallet": "Conectar Carteira",
+      "switchWallet": "Trocar Carteira"
+    }
+  },
+  "network": {
+    "mainnet": "REDE PRINCIPAL",
+    "testnet": "REDE DE TESTE",
+    "switchNetwork": "Trocar de Rede",
+    "currentNetwork": "Rede Atual",
+    "switchTo": "Mudar para {{network}}?",
+    "mainnetWarning": "Aviso: Esta é uma rede de produção. Fundos reais serão usados.",
+    "testnetInfo": "Você está mudando para a Stellar Testnet. As transações usarão XLM de teste.",
+    "mainnetConfirm": "Você está prestes a mudar para a Stellar Mainnet. As transações usarão XLM real.",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar"
+  },
+  "offline": {
+    "banner": {
+      "title": "Você está offline",
+      "description": "Alguns recursos podem estar indisponíveis. As ações serão enfileiradas e processadas quando você voltar a ficar online.",
+      "retry": "Tentar Reconectar",
+      "details": "Detalhes da Conexão"
+    },
+    "status": {
+      "online": "Online",
+      "offline": "Offline",
+      "connecting": "Conectando...",
+      "queueStatus": "{{count}} ação na fila",
+      "queueStatus_plural": "{{count}} ações na fila"
+    },
+    "queue": {
+      "title": "Fila Offline",
+      "description": "{{count}} ação será processada quando você voltar a ficar online",
+      "description_plural": "{{count}} ações serão processadas quando você voltar a ficar online"
+    },
+    "error": {
+      "paymentOffline": "Pagamento enfileirado para quando você voltar a ficar online",
+      "generalOffline": "Ação enfileirada para quando você voltar a ficar online"
+    }
+  },
+  "about": {
+    "title": "Sobre o Wata-Board",
+    "description": "O Wata-Board é uma plataforma descentralizada de pagamento de serviços públicos construída na blockchain Stellar. Permitimos pagamentos de contas de serviços seguros, transparentes e eficientes usando criptomoeda.",
+    "features": {
+      "title": "Principais Recursos",
+      "secure": "Transações Seguras",
+      "secureDescription": "Construído na blockchain Stellar com segurança de nível empresarial",
+      "fast": "Pagamentos Rápidos",
+      "fastDescription": "Liquidação quase instantânea com taxas de transação baixas",
+      "transparent": "Registros Transparentes",
+      "transparentDescription": "Todas as transações são registradas na blockchain pública",
+      "decentralized": "Descentralizado",
+      "decentralizedDescription": "Sem ponto único de falha ou controle"
+    },
+    "howItWorks": {
+      "title": "Como Funciona",
+      "step1": "Conecte sua carteira",
+      "step2": "Insira os dados do medidor",
+      "step3": "Confirme o pagamento",
+      "step4": "Pagamento processado"
+    }
+  },
+  "contact": {
+    "title": "Fale Conosco",
+    "description": "Entre em contato com nossa equipe para suporte, dúvidas ou feedback.",
+    "form": {
+      "name": "Nome",
+      "namePlaceholder": "Digite seu nome",
+      "email": "E-mail",
+      "emailPlaceholder": "Digite seu e-mail",
+      "subject": "Assunto",
+      "subjectPlaceholder": "Digite o assunto",
+      "message": "Mensagem",
+      "messagePlaceholder": "Digite sua mensagem",
+      "sendButton": "Enviar Mensagem",
+      "sending": "Enviando..."
+    },
+    "info": {
+      "email": "E-mail",
+      "support": "Suporte",
+      "website": "Site"
+    }
+  },
+  "rate": {
+    "title": "Avalie sua Experiência",
+    "description": "Ajude-nos a melhorar avaliando sua experiência com o Wata-Board.",
+    "rating": {
+      "excellent": "Excelente",
+      "good": "Bom",
+      "average": "Regular",
+      "poor": "Ruim",
+      "terrible": "Péssimo"
+    },
+    "review": {
+      "title": "Escreva uma Avaliação",
+      "placeholder": "Compartilhe sua experiência com o Wata-Board...",
+      "submit": "Enviar Avaliação",
+      "thankYou": "Obrigado pelo seu feedback!"
+    }
+  },
+  "errors": {
+    "general": {
+      "title": "Erro",
+      "unknown": "Ocorreu um erro desconhecido",
+      "tryAgain": "Por favor, tente novamente",
+      "contactSupport": "Entre em contato com o suporte se o problema persistir"
+    },
+    "network": {
+      "title": "Erro de Rede",
+      "description": "Não foi possível conectar à rede",
+      "checkConnection": "Por favor, verifique sua conexão com a internet"
+    },
+    "wallet": {
+      "title": "Erro de Carteira",
+      "notConnected": "Carteira não conectada",
+      "notInstalled": "Carteira Freighter não instalada",
+      "installFreighter": "Por favor, instale a extensão da carteira Freighter"
+    }
+  },
+  "accessibility": {
+    "skipToMain": "Pular para o conteúdo principal",
+    "skipToNavigation": "Pular para a navegação",
+    "menuToggle": "Alternar menu de navegação",
+    "closeMenu": "Fechar menu",
+    "openMenu": "Abrir menu",
+    "loading": "Carregando...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "warning": "Aviso",
+    "info": "Informação"
+  },
+  "common": {
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "previous": "Anterior",
+    "submit": "Enviar",
+    "reset": "Redefinir",
+    "clear": "Limpar",
+    "search": "Pesquisar",
+    "filter": "Filtrar",
+    "sort": "Ordenar",
+    "loading": "Carregando...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "retry": "Tentar novamente",
+    "refresh": "Atualizar",
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "learnMore": "Saiba Mais",
+    "viewDetails": "Ver Detalhes",
+    "hideDetails": "Ocultar Detalhes"
+  },
+  "time": {
+    "seconds": "segundo",
+    "seconds_plural": "segundos",
+    "minutes": "minuto",
+    "minutes_plural": "minutos",
+    "hours": "hora",
+    "hours_plural": "horas",
+    "days": "dia",
+    "days_plural": "dias",
+    "weeks": "semana",
+    "weeks_plural": "semanas",
+    "months": "mês",
+    "months_plural": "meses",
+    "years": "ano",
+    "years_plural": "anos",
+    "ago": "há {{time}}",
+    "in": "em {{time}}"
+  },
+  "currency": {
+    "xlm": "XLM",
+    "usd": "USD",
+    "eur": "EUR"
+  },
+  "validation": {
+    "required": "Este campo é obrigatório",
+    "invalid": "Formato inválido",
+    "tooShort": "Deve ter pelo menos {{min}} caracteres",
+    "tooLong": "Deve ter no máximo {{max}} caracteres",
+    "invalidEmail": "Por favor, insira um endereço de e-mail válido",
+    "invalidNumber": "Por favor, insira um número válido",
+    "minValue": "Deve ser pelo menos {{min}}",
+    "maxValue": "Deve ser no máximo {{max}}"
+  }
+}

--- a/wata-board-frontend/src/i18n/locales/sw.json
+++ b/wata-board-frontend/src/i18n/locales/sw.json
@@ -1,0 +1,267 @@
+{
+  "app": {
+    "title": "Wata-Board",
+    "tagline": "Malipo ya huduma yaliyogatuliwa kwenye blockchain ya Stellar",
+    "description": "Lipa bili zako za huduma kwa kutumia sarafu ya crypto kwenye mtandao wa Stellar",
+    "footer": {
+      "tagline": "Suluhisho za kisasa za malipo kwa wavuti iliyogatuliwa"
+    }
+  },
+  "navigation": {
+    "home": "Lipa Bili",
+    "about": "Kuhusu",
+    "contact": "Wasiliana",
+    "rate": "Tupime",
+    "language": "Lugha"
+  },
+  "payment": {
+    "form": {
+      "title": "Taarifa za Malipo",
+      "meterNumber": "Namba ya mita",
+      "meterPlaceholder": "mfano MITA-123",
+      "meterDescription": "Ingiza namba ya mita yako ya huduma kama inavyoonekana kwenye bili yako",
+      "amount": "Kiasi",
+      "amountPlaceholder": "Namba nzima",
+      "amountDescription": "Ingiza kiasi cha malipo katika XLM nzima",
+      "payButton": "Lipa bili",
+      "processing": "Inachakatwa...",
+      "rateLimited": "Kikomo kimefikiwa",
+      "requiresExtension": "Inahitaji kiendelezi cha Freighter. Kikomo cha miamala 5 kwa dakika."
+    },
+    "status": {
+      "title": "Hali",
+      "ready": "Tayari.",
+      "installWallet": "Tafadhali sakinisha kiendelezi cha Freighter Wallet!",
+      "enterMeter": "Tafadhali ingiza namba ya mita.",
+      "enterValidAmount": "Tafadhali ingiza kiasi halali kikubwa kuliko 0.",
+      "wholeNumber": "Kiasi lazima kiwe namba nzima.",
+      "amountTooLarge": "Kiasi ni kikubwa sana.",
+      "insufficientBalance": "Salio haitoshi. Tafadhali ongeza XLM zaidi kwenye pochi yako.",
+      "estimatingFees": "Inakadiria ada za muamala... Tafadhali subiri.",
+      "estimationFailed": "Haikuweza kukadiria ada za muamala. Tafadhali jaribu tena.",
+      "paymentSuccess": "Malipo yamefaulu! Kitambulisho cha muamala: {{id}}...",
+      "paymentFailed": "Malipo yameshindwa: {{error}}"
+    },
+    "feeEstimation": {
+      "title": "Makadirio ya Ada ya Muamala",
+      "calculating": "(Inahesabu...)",
+      "calculatingFees": "Inahesabu ada zilizokadiriwa...",
+      "paymentAmount": "Kiasi cha Malipo",
+      "estimatedNetworkFee": "Ada ya Mtandao Iliyokadiriwa",
+      "totalCost": "Gharama ya Jumla",
+      "unableToEstimate": "Haikuweza kukadiria ada kwa sasa"
+    },
+    "rateLimit": {
+      "title": "Hali ya Kikomo cha Kiwango",
+      "requestsAvailable": "{{count}}/5 maombi yanapatikana",
+      "rateLimited": "Kikomo kimefikiwa. Itawekwa upya baada ya {{time}}",
+      "queue": "Foleni: {{count}}"
+    }
+  },
+  "wallet": {
+    "balance": {
+      "title": "Salio la Pochi",
+      "available": "Salio Lipatikanalo",
+      "total": "Salio la Jumla",
+      "loading": "Inapakia salio...",
+      "error": "Imeshindwa kupakia salio",
+      "reconnect": "Tafadhali unganisha pochi yako tena",
+      "insufficient": "Salio haitoshi kwa muamala huu",
+      "lowBalance": "Onyo la salio la chini"
+    },
+    "connection": {
+      "connected": "Imeunganishwa",
+      "disconnected": "Haijaunganishwa",
+      "connecting": "Inaunganisha...",
+      "connectWallet": "Unganisha Pochi",
+      "switchWallet": "Badilisha Pochi"
+    }
+  },
+  "network": {
+    "mainnet": "MTANDAO MIKUU",
+    "testnet": "MTANDAO WA MAJARIBIO",
+    "switchNetwork": "Badilisha Mtandao",
+    "currentNetwork": "Mtandao wa Sasa",
+    "switchTo": "Badilisha hadi {{network}}?",
+    "mainnetWarning": "Onyo: Huu ni mtandao wa uzalishaji. Fedha halisi zitatumika.",
+    "testnetInfo": "Unabadilisha hadi Stellar Testnet. Miamala itatumia XLM za majaribio.",
+    "mainnetConfirm": "Uko karibu kubadilisha hadi Stellar Mainnet. Miamala itatumia XLM halisi.",
+    "cancel": "Ghairi",
+    "confirm": "Thibitisha"
+  },
+  "offline": {
+    "banner": {
+      "title": "Haupo mtandaoni",
+      "description": "Baadhi ya vipengele vinaweza visipatikane. Vitendo vitapangwa kwenye foleni na kushughulikiwa utakaporudi mtandaoni.",
+      "retry": "Jaribu Kuunganisha Tena",
+      "details": "Maelezo ya Muunganisho"
+    },
+    "status": {
+      "online": "Mtandaoni",
+      "offline": "Nje ya mtandao",
+      "connecting": "Inaunganisha...",
+      "queueStatus": "{{count}} kitendo kwenye foleni",
+      "queueStatus_plural": "{{count}} vitendo kwenye foleni"
+    },
+    "queue": {
+      "title": "Foleni ya Nje ya Mtandao",
+      "description": "Kitendo {{count}} kitashughulikiwa utakaporudi mtandaoni",
+      "description_plural": "Vitendo {{count}} vitashughulikiwa utakaporudi mtandaoni"
+    },
+    "error": {
+      "paymentOffline": "Malipo yamepangwa kwenye foleni utakaporudi mtandaoni",
+      "generalOffline": "Kitendo kimepangwa kwenye foleni utakaporudi mtandaoni"
+    }
+  },
+  "about": {
+    "title": "Kuhusu Wata-Board",
+    "description": "Wata-Board ni jukwaa la malipo ya huduma lililogatuliwa lililojengwa kwenye blockchain ya Stellar. Tunawezesha malipo salama, ya uwazi, na yenye ufanisi ya bili za huduma kwa kutumia sarafu ya crypto.",
+    "features": {
+      "title": "Vipengele Muhimu",
+      "secure": "Miamala Salama",
+      "secureDescription": "Imejengwa kwenye blockchain ya Stellar kwa usalama wa kiwango cha biashara",
+      "fast": "Malipo ya Haraka",
+      "fastDescription": "Malipo ya karibu papo hapo kwa ada za chini za muamala",
+      "transparent": "Rekodi za Uwazi",
+      "transparentDescription": "Miamala yote inarekodiwa kwenye blockchain ya umma",
+      "decentralized": "Iliyogatuliwa",
+      "decentralizedDescription": "Hakuna sehemu moja ya kushindwa au udhibiti"
+    },
+    "howItWorks": {
+      "title": "Inavyofanya Kazi",
+      "step1": "Unganisha pochi yako",
+      "step2": "Ingiza maelezo ya mita",
+      "step3": "Thibitisha malipo",
+      "step4": "Malipo yamechakatwa"
+    }
+  },
+  "contact": {
+    "title": "Wasiliana Nasi",
+    "description": "Wasiliana na timu yetu kwa usaidizi, maswali, au maoni.",
+    "form": {
+      "name": "Jina",
+      "namePlaceholder": "Ingiza jina lako",
+      "email": "Barua pepe",
+      "emailPlaceholder": "Ingiza barua pepe yako",
+      "subject": "Mada",
+      "subjectPlaceholder": "Ingiza mada",
+      "message": "Ujumbe",
+      "messagePlaceholder": "Ingiza ujumbe wako",
+      "sendButton": "Tuma Ujumbe",
+      "sending": "Inatuma..."
+    },
+    "info": {
+      "email": "Barua pepe",
+      "support": "Usaidizi",
+      "website": "Tovuti"
+    }
+  },
+  "rate": {
+    "title": "Pima Uzoefu Wako",
+    "description": "Tusaidie kuboresha kwa kupima uzoefu wako na Wata-Board.",
+    "rating": {
+      "excellent": "Bora kabisa",
+      "good": "Nzuri",
+      "average": "Wastani",
+      "poor": "Mbaya",
+      "terrible": "Mbaya sana"
+    },
+    "review": {
+      "title": "Andika Maoni",
+      "placeholder": "Shiriki uzoefu wako na Wata-Board...",
+      "submit": "Tuma Maoni",
+      "thankYou": "Asante kwa maoni yako!"
+    }
+  },
+  "errors": {
+    "general": {
+      "title": "Hitilafu",
+      "unknown": "Hitilafu isiyojulikana imetokea",
+      "tryAgain": "Tafadhali jaribu tena",
+      "contactSupport": "Wasiliana na usaidizi ikiwa tatizo litaendelea"
+    },
+    "network": {
+      "title": "Hitilafu ya Mtandao",
+      "description": "Haikuweza kuunganisha kwenye mtandao",
+      "checkConnection": "Tafadhali angalia muunganisho wako wa intaneti"
+    },
+    "wallet": {
+      "title": "Hitilafu ya Pochi",
+      "notConnected": "Pochi haijaunganishwa",
+      "notInstalled": "Pochi ya Freighter haijasakinishwa",
+      "installFreighter": "Tafadhali sakinisha kiendelezi cha pochi cha Freighter"
+    }
+  },
+  "accessibility": {
+    "skipToMain": "Ruka hadi kwenye maudhui makuu",
+    "skipToNavigation": "Ruka hadi kwenye urambazaji",
+    "menuToggle": "Badilisha menyu ya urambazaji",
+    "closeMenu": "Funga menyu",
+    "openMenu": "Fungua menyu",
+    "loading": "Inapakia...",
+    "error": "Hitilafu",
+    "success": "Imefaulu",
+    "warning": "Onyo",
+    "info": "Taarifa"
+  },
+  "common": {
+    "cancel": "Ghairi",
+    "confirm": "Thibitisha",
+    "save": "Hifadhi",
+    "delete": "Futa",
+    "edit": "Hariri",
+    "close": "Funga",
+    "back": "Nyuma",
+    "next": "Inayofuata",
+    "previous": "Iliyotangulia",
+    "submit": "Wasilisha",
+    "reset": "Weka upya",
+    "clear": "Futa",
+    "search": "Tafuta",
+    "filter": "Chuja",
+    "sort": "Panga",
+    "loading": "Inapakia...",
+    "error": "Hitilafu",
+    "success": "Imefaulu",
+    "retry": "Jaribu tena",
+    "refresh": "Onyesha upya",
+    "copy": "Nakili",
+    "copied": "Imenakiliwa!",
+    "learnMore": "Jifunze Zaidi",
+    "viewDetails": "Angalia Maelezo",
+    "hideDetails": "Ficha Maelezo"
+  },
+  "time": {
+    "seconds": "sekunde",
+    "seconds_plural": "sekunde",
+    "minutes": "dakika",
+    "minutes_plural": "dakika",
+    "hours": "saa",
+    "hours_plural": "saa",
+    "days": "siku",
+    "days_plural": "siku",
+    "weeks": "wiki",
+    "weeks_plural": "wiki",
+    "months": "mwezi",
+    "months_plural": "miezi",
+    "years": "mwaka",
+    "years_plural": "miaka",
+    "ago": "{{time}} iliyopita",
+    "in": "katika {{time}}"
+  },
+  "currency": {
+    "xlm": "XLM",
+    "usd": "USD",
+    "eur": "EUR"
+  },
+  "validation": {
+    "required": "Sehemu hii inahitajika",
+    "invalid": "Muundo batili",
+    "tooShort": "Lazima iwe angalau herufi {{min}}",
+    "tooLong": "Lazima isizidi herufi {{max}}",
+    "invalidEmail": "Tafadhali ingiza anwani halali ya barua pepe",
+    "invalidNumber": "Tafadhali ingiza namba halali",
+    "minValue": "Lazima iwe angalau {{min}}",
+    "maxValue": "Lazima isizidi {{max}}"
+  }
+}

--- a/wata-board-frontend/tests/locale-coverage.spec.ts
+++ b/wata-board-frontend/tests/locale-coverage.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+const NEW_LOCALES = ['fr-CA', 'pt-BR', 'sw'] as const;
+
+test.describe('New locale coverage', () => {
+  for (const locale of NEW_LOCALES) {
+    test(`/${locale} renders without missing-key warnings`, async ({ page }) => {
+      const missingKeys: string[] = [];
+
+      page.on('console', (msg) => {
+        const text = msg.text();
+        if (text.includes('i18next') && text.includes('missing')) {
+          missingKeys.push(text);
+        }
+      });
+
+      // Set the locale before navigation (this project uses localStorage, not URL path)
+      await page.addInitScript((lng) => {
+        localStorage.setItem('wata-board-language', lng);
+      }, locale);
+
+      await page.goto('/');
+      await page.waitForSelector('h1', { timeout: 15000 });
+
+      // Verify the locale is active
+      const activeLang = await page.evaluate(() =>
+        localStorage.getItem('wata-board-language'),
+      );
+      expect(activeLang).toBe(locale);
+
+      // Assert no missing translation keys
+      expect(missingKeys).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
…d e2e coverage

Problem
- Crisis response contexts are dominant in French (Canadian), Portuguese (Brazilian), and Swahili-speaking regions
- App only declared ['en', 'es', 'fr'] as supported languages
- i18next was configured with load: 'languageOnly', which ignored region-specific locale codes like fr-CA and pt-BR

Changes
1. Translation files (src/i18n/locales/)
   - fr-CA.json: 13-section Canadian French translations using Quebec terminology (courriel, soutien, portefeuille)
   - pt-BR.json: 13-section Brazilian Portuguese translations
   - sw.json: 13-section Swahili translations

2. i18n configuration (src/i18n/index.ts)
   - Imported and registered all three new locale resources
   - Added entries to supportedLanguages array with country flags
   - Changed load from 'languageOnly' to 'all' so region-specific locale codes (fr-CA, pt-BR) are respected
   - Added new locale codes to the preload array
   - Added toIntlLocale() helper to map i18n language codes to Intl-compatible locale IDs (e.g. sw -> sw-TZ, zh -> zh-CN)
   - Refactored formatNumber, formatCurrency, formatDate to use the new helper for maintainability

3. E2e test (tests/locale-coverage.spec.ts)
   - Playwright test that navigates to the app with each new locale set via localStorage
   - Listens for i18next missing-key warnings on the console
   - Asserts zero missing-key warnings for fr-CA, pt-BR, and sw
   - All 3 tests pass on Chromium

4. Pre-existing bug fixes
   - ResponsiveNavigation.tsx: removed duplicate LanguageSwitcher import
   - network-config.ts: removed unused old type definitions and NETWORKS constant (lines 1-75) that conflicted with newer declarations

Verification
- TypeScript compilation: 0 errors (tsc --noEmit)
- All 3 new e2e tests pass
- 35/40 total Playwright tests pass (5 pre-existing failures unrelated to this change)