### PR TITLE
Fix QR emergency scan page caching

### DIFF
--- a/src/pages/scan/[id].tsx
+++ b/src/pages/scan/[id].tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { GetStaticProps, GetStaticPaths } from 'next';
+import { GetServerSideProps } from 'next';
 import { AlertOctagon, Phone, MapPin, Stethoscope, Dna, ExternalLink, QrCode } from 'lucide-react';
 import { qrcodeAPI } from '@/lib/api/qrcodeAPI';
 import { petAPI } from '@/lib/api/petAPI';
 import { PetEmergencyInfo, EmergencyContact } from '@/types/pet';
 
-export const dynamic = 'force-dynamic';
+// export const dynamic = 'force-dynamic';
 
 interface PublicProfile {
   qrCodeId: string;
@@ -17,13 +17,20 @@ interface PublicProfile {
   emergency: PetEmergencyInfo | null;
 }
 
-export default function ScanPage() {
+interface ScanPageProps {
+  profile: PublicProfile | null;
+  error: string | null;
+}
+
+export default function ScanPage({
+  profile: initialProfile,
+  error: initialError,
+}: ScanPageProps) {
   const router = useRouter();
   const { id } = router.query;
-  const [profile, setProfile] = useState<PublicProfile | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
+  const [profile, setProfile] = useState(initialProfile);
+  const [error, setError] = useState(initialError);
+  const [loading, setLoading] = useState(false);
   useEffect(() => {
     if (!id || typeof id !== 'string') return;
 
@@ -31,7 +38,7 @@ export default function ScanPage() {
       try {
         // Record the scan (best-effort, non-blocking)
         const deviceType = /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop';
-        qrcodeAPI.recordScan(id, { deviceType }).catch(() => {});
+        qrcodeAPI.recordScan(id, { deviceType }).catch(() => { });
 
         const qr = await qrcodeAPI.getOne(id);
 
@@ -266,17 +273,8 @@ export default function ScanPage() {
     </div>
   );
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: 'blocking',
-  };
-};
-
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps = async () => {
   return {
     props: {},
-    revalidate: false,
   };
 };


### PR DESCRIPTION
## Summary

This PR updates the QR emergency scan page to avoid permanent static caching.

### Changes

- Replaced `getStaticProps`/`getStaticPaths` with `getServerSideProps`
- Removed the misleading static generation configuration

### Testing

- Ran the application locally
- Existing tests pass (`npm test`)