### PR TITLE
Fix mojibake in PWA banners and wire up dead admin buttons

### DIFF
--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -53,7 +53,7 @@ export function PWAUpdateBanner({ onUpdate, onDismiss }: PWAUpdateBannerProps) {
       role="alert"
       className="fixed top-4 left-4 right-4 z-50 max-w-sm mx-auto bg-blue-600 text-white rounded-2xl shadow-2xl p-4 flex items-center gap-3"
     >
-      <span className="text-xl flex-shrink-0">≡ƒöä</span>
+      <span className="text-xl flex-shrink-0">🔄</span>
       <div className="flex-1 min-w-0">
         <p className="font-semibold text-sm">Update available</p>
         <p className="text-xs text-blue-100">A new version of PetChain is ready.</p>
@@ -88,7 +88,7 @@ export function OfflineBanner({ isOffline }: OfflineBannerProps) {
       aria-live="polite"
       className="fixed top-0 left-0 right-0 z-50 bg-amber-500 text-white text-center text-sm py-2 px-4 font-medium"
     >
-      ≡ƒôí You&apos;re offline ΓÇö showing cached data
+      📵 You&apos;re offline — showing cached data
     </div>
   );
 }

--- a/src/pages/admin/reports.tsx
+++ b/src/pages/admin/reports.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { GetServerSideProps } from 'next';
 import Header from '@/components/Header';
 import ProtectedRoute from '@/components/ProtectedRoute';
-import { Download, Calendar, Activity, DollarSign, ActivitySquare, LayoutDashboard, FileText } from 'lucide-react';
+import { Printer, Calendar, Activity, DollarSign, ActivitySquare, LayoutDashboard, FileText } from 'lucide-react';
 import dynamic from 'next/dynamic';
 
 // Import Charts with dynamic loading
@@ -195,8 +195,8 @@ export default function AdminReports() {
                             onClick={handlePrint}
                             className="bg-blue-600 hover:bg-blue-700 text-white px-5 py-2.5 rounded-xl font-medium flex items-center gap-2 transition-all shadow-md hover:shadow-lg active:scale-95"
                         >
-                            <Download className="w-5 h-5" />
-                            Export Data
+                            <Printer className="w-5 h-5" />
+                            Print Report
                         </button>
                     </div>
 
@@ -405,9 +405,6 @@ export default function AdminReports() {
                             <div className="bg-white p-8 rounded-3xl shadow-lg border border-slate-100 animate-in fade-in slide-in-from-bottom-4 duration-500 print:hidden">
                                 <div className="flex justify-between items-center mb-6">
                                     <h3 className="text-xl font-bold text-slate-800">Automated Report Deliveries</h3>
-                                    <button className="bg-slate-900 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-slate-800">
-                                        + New Schedule
-                                    </button>
                                 </div>
 
                                 <div className="overflow--auto">
@@ -418,7 +415,6 @@ export default function AdminReports() {
                                                 <th className="py-4 font-semibold text-slate-500">Frequency</th>
                                                 <th className="py-4 font-semibold text-slate-500">Recipients</th>
                                                 <th className="py-4 font-semibold text-slate-500">Next Run</th>
-                                                <th className="py-4 font-semibold text-slate-500 text-right">Actions</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -434,9 +430,6 @@ export default function AdminReports() {
                                                     </td>
                                                     <td className="py-4 text-slate-600">{report.rec}</td>
                                                     <td className="py-4 text-slate-600">{report.next}</td>
-                                                    <td className="py-4 text-right">
-                                                        <button className="text-blue-600 hover:text-blue-800 font-medium text-sm">Edit</button>
-                                                    </td>
                                                 </tr>
                                             ))}
                                         </tbody>

--- a/src/pages/admin/security.tsx
+++ b/src/pages/admin/security.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { Shield, AlertTriangle, Activity, Users, Clock, CheckCircle, XCircle, Home, Settings, LogOut } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface SecurityMetrics {
   totalEvents: number;
@@ -40,11 +41,18 @@ interface RealTimeAlert {
 
 export default function SecurityDashboard() {
   const router = useRouter();
+  const { logout } = useAuth();
   const [metrics, setMetrics] = useState<SecurityMetrics | null>(null);
   const [alerts, setAlerts] = useState<RealTimeAlert[]>([]);
   const [loading, setLoading] = useState(true);
   const [timeRange, setTimeRange] = useState<'1h' | '24h' | '7d'>('24h');
   const [activeTab, setActiveTab] = useState('events');
+
+  const handleLogout = async () => {
+    if (confirm('Are you sure you want to log out?')) {
+      await logout();
+    }
+  };
 
   useEffect(() => {
     fetchSecurityData();
@@ -135,7 +143,7 @@ export default function SecurityDashboard() {
                 <Link href="/settings" className="text-gray-700 hover:text-gray-900">
                   <Settings className="h-5 w-5" />
                 </Link>
-                <button className="text-red-600 hover:text-red-500">
+                <button onClick={handleLogout} className="text-red-600 hover:text-red-500">
                   <LogOut className="h-5 w-5" />
                 </button>
               </div>
@@ -168,7 +176,7 @@ export default function SecurityDashboard() {
                 <Settings className="h-5 w-5" />
                 <span>Settings</span>
               </Link>
-              <button className="text-red-600 hover:text-red-500 flex items-center space-x-1">
+              <button onClick={handleLogout} className="text-red-600 hover:text-red-500 flex items-center space-x-1">
                 <LogOut className="h-5 w-5" />
                 <span>Logout</span>
               </button>


### PR DESCRIPTION
this pr closes #770 
this pr closes #769 
this pr closes #768 
this pr closes #767 

PWAInstallPrompt.tsx: PWAUpdateBanner and OfflineBanner contained corrupted byte sequences (≡ƒöä, ≡ƒôí, ΓÇö) from a UTF-8/encoding mismatch instead of the intended emoji and em dash. Replaced with correctly encoded 🔄 and "📵 You're offline — showing cached data", both rendered directly to users on update-available and offline states.

admin/reports.tsx: the "Export Data" button (Download icon) never exported anything — it just triggered window.print() on whichever tab was active, silently excluding the other five report categories. Renamed it to "Print Report" with a Printer icon to match its actual behavior instead of promising a file download it doesn't deliver. Also removed the "+ New Schedule" and per-row "Edit" buttons in the Scheduled Reports tab, which had no onClick handlers and did nothing — report scheduling isn't implemented anywhere in this codebase, so the dead controls were removed along with the now-unused Actions column rather than shipping non-functional UI.

admin/security.tsx: both Logout buttons (loading-skeleton nav and main nav) rendered icon/label only with no onClick, and the page never imported useAuth, so there was no working way to log out from the Security Dashboard. Wired both buttons to a handleLogout that matches the confirm-dialog + logout() pattern already used in Header.tsx and dashboard.tsx.