### PR TITLE
fix(search): show empty state for global search with zero results

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,3 +1,25 @@
+export function SearchEmptyState({ message = 'No results found' }: { message?: string }) {
+  return (
+    <div className="text-center py-12">
+      <svg
+        className="mx-auto h-12 w-12 text-gray-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      <h3 className="mt-2 text-lg font-medium text-gray-900">{message}</h3>
+      <p className="mt-1 text-sm text-gray-500">Try adjusting your search or filters</p>
+    </div>
+  );
+}
+
 interface SearchResultsProps<T = any> {
   results: T[];
   total: number;
@@ -32,25 +54,7 @@ export default function SearchResults<T = any>({
   }
 
   if (!results || results.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <svg
-          className="mx-auto h-12 w-12 text-gray-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-        <h3 className="mt-2 text-lg font-medium text-gray-900">{emptyMessage}</h3>
-        <p className="mt-1 text-sm text-gray-500">Try adjusting your search or filters</p>
-      </div>
-    );
+    return <SearchEmptyState message={emptyMessage} />;
   }
 
   return (

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import { useState } from 'react';
 import type React from 'react';
 import SearchBar, { SearchFilters } from '../components/SearchBar';
-import SearchResults from '../components/SearchResults';
+import SearchResults, { SearchEmptyState } from '../components/SearchResults';
 
 export const dynamic = 'force-dynamic';
 
@@ -207,6 +207,18 @@ export default function SearchPage() {
 
   const renderGlobalResults = () => {
     if (!searchResults) return null;
+
+    const hasResults =
+      (searchResults.pets?.results?.length ?? 0) > 0 ||
+      (searchResults.vets?.results?.length ?? 0) > 0 ||
+      (searchResults.medicalRecords?.results?.length ?? 0) > 0 ||
+      (searchResults.emergencyServices?.results?.length ?? 0) > 0;
+
+    if (!hasResults) {
+      return (
+        <SearchEmptyState message="No results found across pets, vets, medical records, or emergency services" />
+      );
+    }
 
     return (
       <div className="space-y-8">


### PR DESCRIPTION
closes #773

## Summary
- Extracted `SearchResults`'s empty-state markup into a reusable, exported `SearchEmptyState` component so it isn't duplicated.
- `SearchResults` now renders `SearchEmptyState` internally (no visual change for the per-type tabs).
- `renderGlobalResults` in `src/pages/search.tsx` now detects when all four category result arrays (pets, vets, medical records, emergency services) are empty and renders `SearchEmptyState` with a global-appropriate message instead of an empty `<div>`.

## Testing/Validation Performed
- `npx tsc --noEmit` — no new type errors introduced (pre-existing unrelated errors in other files untouched)
- `npx eslint src/pages/search.tsx src/components/SearchResults.tsx` — 0 errors (pre-existing warnings only)
- `npx prettier --check src/pages/search.tsx src/components/SearchResults.tsx` — passes
- `npm test -- --passWithNoTests --ci` — 16/16 passing
- `npx next build` — builds successfully