### PR TITLE
fix(images): configure next/image remote domains and add safe fallback

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { REMOTE_IMAGE_HOSTS } from "./src/lib/images/remoteImageHosts";
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
@@ -13,6 +14,9 @@ const nextConfig: NextConfig = {
   onDemandEntries: {
     maxInactiveAge: 60 * 60 * 1000,
     pagesBufferLength: 50,
+  },
+  images: {
+    remotePatterns: REMOTE_IMAGE_HOSTS,
   },
 };
 

--- a/src/components/Clinics/ClinicCard.tsx
+++ b/src/components/Clinics/ClinicCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import Image from "next/image";
+import SafeImage from "@/components/SafeImage";
 import { Star, MapPin, Clock, ArrowRight } from "lucide-react";
 import { Clinic } from "@/types/clinic";
 
@@ -13,7 +13,7 @@ export default function ClinicCard({ clinic }: ClinicCardProps) {
     <div className="bg-white/80 backdrop-blur-sm rounded-3xl p-5 shadow-xl border border-white/40 hover:shadow-2xl transition-all group flex flex-col h-full">
       <div className="relative h-40 w-full mb-4 overflow-hidden rounded-2xl">
         {clinic.mainImage ? (
-          <Image
+          <SafeImage
             src={clinic.mainImage}
             alt={clinic.name}
             fill

--- a/src/components/Clinics/StaffList.tsx
+++ b/src/components/Clinics/StaffList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Image from "next/image";
+import SafeImage from "@/components/SafeImage";
 import { StaffMember } from "@/types/clinic";
 
 interface StaffListProps {
@@ -16,7 +16,7 @@ export default function StaffList({ staff }: StaffListProps) {
         >
           <div className="w-16 h-16 rounded-full overflow-hidden bg-blue-50 shrink-0 border-2 border-white shadow-sm relative">
             {member.avatar ? (
-              <Image
+              <SafeImage
                 src={member.avatar}
                 alt={member.name}
                 fill

--- a/src/components/SafeImage.tsx
+++ b/src/components/SafeImage.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+import Image, { ImageProps } from 'next/image';
+import { isAllowedImageSrc } from '@/lib/images/remoteImageHosts';
+
+const DEFAULT_FALLBACK_SRC = '/file.svg';
+
+interface SafeImageProps extends Omit<ImageProps, 'src' | 'onError'> {
+  src?: string | null;
+  fallbackSrc?: string;
+}
+
+/**
+ * Wraps next/image so a missing photo URL, an unlisted remote host, or a
+ * broken/404 image can't crash the page — it degrades to a placeholder
+ * instead of letting next/image throw its "hostname not configured" error.
+ */
+export default function SafeImage({
+  src,
+  fallbackSrc = DEFAULT_FALLBACK_SRC,
+  alt,
+  ...props
+}: SafeImageProps) {
+  const [hasError, setHasError] = useState(false);
+
+  const resolvedSrc = !src || hasError || !isAllowedImageSrc(src) ? fallbackSrc : src;
+
+  return <Image {...props} src={resolvedSrc} alt={alt} onError={() => setHasError(true)} />;
+}

--- a/src/lib/images/remoteImageHosts.test.ts
+++ b/src/lib/images/remoteImageHosts.test.ts
@@ -1,0 +1,38 @@
+import { isAllowedImageHost, isAllowedImageSrc, REMOTE_IMAGE_HOSTS } from './remoteImageHosts';
+
+describe('remoteImageHosts', () => {
+  it('declares at least one remote pattern for every real photo host', () => {
+    expect(REMOTE_IMAGE_HOSTS.length).toBeGreaterThan(0);
+  });
+
+  it('allows known S3 bucket hosts', () => {
+    expect(isAllowedImageHost('petchain-uploads.s3.amazonaws.com')).toBe(true);
+    expect(isAllowedImageHost('petchain-uploads.s3.us-east-1.amazonaws.com')).toBe(true);
+  });
+
+  it('allows Google Cloud Storage', () => {
+    expect(isAllowedImageHost('storage.googleapis.com')).toBe(true);
+  });
+
+  it('allows known IPFS gateways', () => {
+    expect(isAllowedImageHost('ipfs.io')).toBe(true);
+    expect(isAllowedImageHost('gateway.pinata.cloud')).toBe(true);
+    expect(isAllowedImageHost('petchain.infura-ipfs.io')).toBe(true);
+  });
+
+  it('rejects an unlisted/unexpected host', () => {
+    expect(isAllowedImageHost('evil.example.com')).toBe(false);
+  });
+
+  it('treats relative/same-origin src values as allowed', () => {
+    expect(isAllowedImageSrc('/uploads/photo.jpg')).toBe(true);
+  });
+
+  it('rejects an absolute src on an unlisted host', () => {
+    expect(isAllowedImageSrc('https://evil.example.com/photo.jpg')).toBe(false);
+  });
+
+  it('allows an absolute src on an allow-listed host', () => {
+    expect(isAllowedImageSrc('https://storage.googleapis.com/bucket/photo.jpg')).toBe(true);
+  });
+});

--- a/src/lib/images/remoteImageHosts.ts
+++ b/src/lib/images/remoteImageHosts.ts
@@ -1,0 +1,64 @@
+export interface RemoteImageHost {
+  protocol: 'http' | 'https';
+  hostname: string;
+}
+
+function cdnHostFromEnv(): RemoteImageHost | null {
+  const endpoint = process.env.CDN_ENDPOINT || process.env.NEXT_PUBLIC_CDN_ENDPOINT;
+  if (!endpoint) return null;
+
+  try {
+    const url = new URL(endpoint);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return { protocol: url.protocol.replace(':', '') as 'http' | 'https', hostname: url.hostname };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Real-world origins the backend serves user-uploaded pet/clinic/staff photos
+ * from: AWS S3, Google Cloud Storage, IPFS gateways, and the configured CDN.
+ * Used both by next.config.ts (images.remotePatterns) and SafeImage, so the
+ * two stay in sync and a new host only needs to be added in one place.
+ */
+export const REMOTE_IMAGE_HOSTS: RemoteImageHost[] = [
+  { protocol: 'https', hostname: '*.s3.amazonaws.com' },
+  { protocol: 'https', hostname: '*.s3.*.amazonaws.com' },
+  { protocol: 'https', hostname: 'storage.googleapis.com' },
+  { protocol: 'https', hostname: 'ipfs.io' },
+  { protocol: 'https', hostname: '*.infura-ipfs.io' },
+  { protocol: 'https', hostname: 'gateway.pinata.cloud' },
+  ...(() => {
+    const cdnHost = cdnHostFromEnv();
+    return cdnHost ? [cdnHost] : [];
+  })(),
+];
+
+function hostPatternToRegExp(hostname: string): RegExp {
+  const escaped = hostname
+    .split('**')
+    .map((part) =>
+      part
+        .split('*')
+        .map((segment) => segment.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+        .join('[^.]*')
+    )
+    .join('.*');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+export function isAllowedImageHost(hostname: string): boolean {
+  return REMOTE_IMAGE_HOSTS.some((host) => hostPatternToRegExp(host.hostname).test(hostname));
+}
+
+export function isAllowedImageSrc(src: string): boolean {
+  try {
+    const url = new URL(src);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    return isAllowedImageHost(url.hostname);
+  } catch {
+    // Relative/same-origin paths (e.g. "/photo.jpg") don't need an allow-listed host.
+    return true;
+  }
+}

--- a/src/pages/pets/[id].tsx
+++ b/src/pages/pets/[id].tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import Image from 'next/image';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { ArrowLeft, PawPrint } from 'lucide-react';
 import { PetPhotosManager } from '@/components/PetPhotos';
+import SafeImage from '@/components/SafeImage';
 import { EmergencyQR } from '@/components/Profile/EmergencyQR';
 import styles from '@/styles/pages/PetDetailPage.module.css';
 import { getApiBaseUrl } from '@/lib/api/apiBaseUrl';
@@ -105,7 +105,7 @@ export default function PetDetailPage() {
 
         <div className={styles.petHeader}>
           {primaryPhoto ? (
-            <Image
+            <SafeImage
               src={primaryPhoto.thumbnailUrl || primaryPhoto.photoUrl}
               alt={pet.name}
               fill


### PR DESCRIPTION
closes #774

## Summary
`next.config.ts` had no `images.domains`/`images.remotePatterns`, so `next/image` throws a hard runtime error the first time a dynamic `src` (avatar, clinic photo, pet photo) resolves to a non-same-origin host — the expected case for backend-hosted uploads (S3, GCS, IPFS gateway, CDN).

- Added `src/lib/images/remoteImageHosts.ts`: a single source of truth listing allow-listed remote photo hosts (S3, GCS, IPFS gateways, and an optional CDN host derived from `CDN_ENDPOINT`/`NEXT_PUBLIC_CDN_ENDPOINT`), consumed by both `next.config.ts` and the client.
- Wired `REMOTE_IMAGE_HOSTS` into `next.config.ts`'s `images.remotePatterns` (preferred over the deprecated `domains`).
- Added `SafeImage`, a `next/image` wrapper that pre-validates `src` against the allow-list and falls back to a same-origin placeholder (`/file.svg`) on an unlisted host, a missing URL, or a broken image load (`onError`) — so a single bad/unexpected photo URL can't crash the page.
- Swapped `next/image` for `SafeImage` at the three call sites feeding dynamic backend URLs: `StaffList.tsx`, `ClinicCard.tsx`, `pets/[id].tsx`.
- Added regression tests (`remoteImageHosts.test.ts`) covering S3/GCS/IPFS hosts, an unlisted host, and same-origin/relative src values — these guard `next.config.ts`'s allow-list since it imports the same module.


## Testing/Validation Performed
- `npx jest src/lib/images/remoteImageHosts.test.ts` — 8/8 passing
- `npx tsc --noEmit` — no new type errors introduced (pre-existing unrelated errors in other files untouched)
- `npx eslint <changed files>` — no new errors (pre-existing warnings/errors on `next.config.ts`'s require-import and `pets/[id].tsx`'s unrelated `QrCode` reference predate this change)
- `npx prettier --check` on new files — passes (pre-existing formatting deviations in `next.config.ts`/`StaffList.tsx`/`ClinicCard.tsx` predate this change and were left untouched to keep the diff scoped)
- `npm test -- --passWithNoTests --ci` — 16/16 passing
- `npx next build` — builds successfully, confirms `next.config.ts` can import the local `remoteImageHosts` module