### PR TITLE
fix(notifications): persist preferences to backend, not just localStorage

### DIFF
--- a/src/components/Notifications/NotificationPreferencesPanel.tsx
+++ b/src/components/Notifications/NotificationPreferencesPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNotifications } from '@/contexts/NotificationContext';
 import { NotificationCategory, CATEGORY_LABELS, CATEGORY_ICONS } from '@/types/notification';
 
@@ -49,13 +48,13 @@ function Toggle({
 const CATEGORIES = Object.keys(CATEGORY_LABELS) as NotificationCategory[];
 
 export default function NotificationPreferencesPanel() {
-  const { preferences, updatePreferences, requestBrowserPermission } = useNotifications();
-  const [saved, setSaved] = useState(false);
-
-  const save = () => {
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  };
+  const {
+    preferences,
+    updatePreferences,
+    syncPreferences,
+    requestBrowserPermission,
+    preferencesSyncStatus,
+  } = useNotifications();
 
   return (
     <div className="space-y-6">
@@ -175,11 +174,23 @@ export default function NotificationPreferencesPanel() {
       </section>
 
       <button
-        onClick={save}
-        className="w-full py-3 bg-blue-600 text-white font-semibold rounded-2xl hover:bg-blue-700 transition-colors min-h-[44px]"
+        onClick={syncPreferences}
+        disabled={preferencesSyncStatus === 'saving'}
+        className="w-full py-3 bg-blue-600 text-white font-semibold rounded-2xl hover:bg-blue-700 transition-colors min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        {saved ? '✓ Saved' : 'Save preferences'}
+        {preferencesSyncStatus === 'saving'
+          ? 'Saving…'
+          : preferencesSyncStatus === 'error'
+            ? 'Retry save'
+            : preferencesSyncStatus === 'saved'
+              ? '✓ Saved'
+              : 'Save preferences'}
       </button>
+      {preferencesSyncStatus === 'error' && (
+        <p className="text-xs text-red-600 text-center -mt-4">
+          Couldn&apos;t save your preferences. Check your connection and try again.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -20,11 +20,14 @@ import { useAuth } from '@/contexts/AuthContext';
 
 // ─── State ────────────────────────────────────────────────────────────────────
 
+type PreferencesSyncStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 interface NotificationState {
   notifications: AppNotification[];
   unreadCount: number;
   toasts: ToastNotification[];
   preferences: NotificationPreferences;
+  preferencesSyncStatus: PreferencesSyncStatus;
   isConnected: boolean;
   isCenterOpen: boolean;
   activeFilter: NotificationCategory | 'ALL';
@@ -40,6 +43,7 @@ type Action =
   | { type: 'ADD_TOAST'; payload: ToastNotification }
   | { type: 'REMOVE_TOAST'; id: string }
   | { type: 'SET_PREFS'; payload: NotificationPreferences }
+  | { type: 'SET_PREFS_SYNC_STATUS'; value: PreferencesSyncStatus }
   | { type: 'SET_CONNECTED'; value: boolean }
   | { type: 'TOGGLE_CENTER' }
   | { type: 'SET_FILTER'; filter: NotificationCategory | 'ALL' }
@@ -81,6 +85,8 @@ function reducer(state: NotificationState, action: Action): NotificationState {
       return { ...state, toasts: state.toasts.filter((t) => t.id !== action.id) };
     case 'SET_PREFS':
       return { ...state, preferences: action.payload };
+    case 'SET_PREFS_SYNC_STATUS':
+      return { ...state, preferencesSyncStatus: action.value };
     case 'SET_CONNECTED':
       return { ...state, isConnected: action.value };
     case 'TOGGLE_CENTER':
@@ -104,6 +110,7 @@ interface NotificationContextType extends NotificationState {
   toggleCenter: () => void;
   setFilter: (f: NotificationCategory | 'ALL') => void;
   updatePreferences: (p: Partial<NotificationPreferences>) => void;
+  syncPreferences: () => Promise<void>;
   requestBrowserPermission: () => Promise<void>;
   filteredNotifications: AppNotification[];
   bellRef: React.RefObject<HTMLButtonElement | null>;
@@ -180,17 +187,26 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectDelay = useRef(1000);
+  const preferencesRef = useRef<NotificationPreferences>(loadPrefs());
 
   const [state, dispatch] = useReducer(reducer, {
     notifications: [],
     unreadCount: 0,
     toasts: [],
     preferences: loadPrefs(),
+    preferencesSyncStatus: 'idle',
     isConnected: false,
     isCenterOpen: false,
     activeFilter: 'ALL',
     isLoading: false,
   });
+
+  // Keep a ref in sync with the latest preferences so callbacks with stable
+  // deps (handleIncoming, the toast subscription) always read the current,
+  // in-memory preferences instead of re-reading localStorage.
+  useEffect(() => {
+    preferencesRef.current = state.preferences;
+  }, [state.preferences]);
 
   // ── Load persisted + fetch from API ────────────────────────────────────────
   useEffect(() => {
@@ -214,6 +230,19 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         /* use cached */
       })
       .finally(() => dispatch({ type: 'SET_LOADING', value: false }));
+
+    // Hydrate preferences from the backend so they follow the user across
+    // devices; the localStorage cache above stays as the offline-first
+    // fallback if the request fails.
+    notificationsAPI
+      .getPreferences(user.id, loadPrefs())
+      .then((prefs) => {
+        dispatch({ type: 'SET_PREFS', payload: prefs });
+        savePrefs(prefs);
+      })
+      .catch(() => {
+        /* backend unreachable — keep local cache */
+      });
   }, [isAuthenticated, user]);
 
   // ── WebSocket ───────────────────────────────────────────────────────────────
@@ -276,7 +305,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   // ── Subscribe to notificationService events ──────────────────────────────
   useEffect(() => {
     const unsub = notificationService.on('notification', (inApp) => {
-      const prefs = loadPrefs();
+      const prefs = preferencesRef.current;
       if (inApp.category && !prefs.categories[inApp.category]) return;
       dispatch({
         type: 'ADD_TOAST',
@@ -288,7 +317,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
   // ── Incoming notification handler ───────────────────────────────────────────
   const handleIncoming = useCallback((notif: AppNotification) => {
-    const prefs = loadPrefs();
+    const prefs = preferencesRef.current;
 
     // Category filter
     if (!prefs.categories[notif.category as NotificationCategory]) return;
@@ -386,13 +415,33 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     dispatch({ type: 'SET_FILTER', filter: f });
   }, []);
 
+  const persistPreferences = useCallback(
+    async (next: NotificationPreferences) => {
+      if (!user) return;
+      dispatch({ type: 'SET_PREFS_SYNC_STATUS', value: 'saving' });
+      try {
+        await notificationsAPI.updatePreferences(user.id, next);
+        dispatch({ type: 'SET_PREFS_SYNC_STATUS', value: 'saved' });
+      } catch {
+        dispatch({ type: 'SET_PREFS_SYNC_STATUS', value: 'error' });
+      }
+    },
+    [user]
+  );
+
   const updatePreferences = useCallback(
     (p: Partial<NotificationPreferences>) => {
       const next = { ...state.preferences, ...p };
       dispatch({ type: 'SET_PREFS', payload: next });
-      savePrefs(next);
+      savePrefs(next); // offline-first cache; backend below is the source of truth
+      void persistPreferences(next);
     },
-    [state.preferences]
+    [state.preferences, persistPreferences]
+  );
+
+  const syncPreferences = useCallback(
+    () => persistPreferences(state.preferences),
+    [persistPreferences, state.preferences]
   );
 
   const requestBrowserPermission = useCallback(async () => {
@@ -419,6 +468,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         toggleCenter,
         setFilter,
         updatePreferences,
+        syncPreferences,
         requestBrowserPermission,
         filteredNotifications,
         bellRef,

--- a/src/lib/api/notificationsAPI.test.ts
+++ b/src/lib/api/notificationsAPI.test.ts
@@ -1,0 +1,65 @@
+import axios from 'axios';
+import { DEFAULT_PREFERENCES } from '@/types/notification';
+
+jest.mock('axios', () => {
+  const mockInstance = {
+    get: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    interceptors: { request: { use: jest.fn() } },
+  };
+  return {
+    __esModule: true,
+    default: { create: jest.fn(() => mockInstance) },
+  };
+});
+
+import { notificationsAPI } from './notificationsAPI';
+
+const mockAxiosInstance = (axios.create as jest.Mock).mock.results[0].value;
+
+describe('notificationsAPI preferences persistence', () => {
+  beforeEach(() => {
+    mockAxiosInstance.get.mockReset();
+    mockAxiosInstance.patch.mockReset();
+  });
+
+  it('merges backend category settings onto the cached preferences fallback', async () => {
+    mockAxiosInstance.get.mockResolvedValue({
+      data: { appointment: false, medication: true, lostPet: false },
+    });
+
+    const result = await notificationsAPI.getPreferences('user-1', DEFAULT_PREFERENCES);
+
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('/user-1/settings');
+    expect(result.categories.APPOINTMENT).toBe(false);
+    expect(result.categories.MEDICATION).toBe(true);
+    expect(result.categories.LOST_PET).toBe(false);
+    // Fields the backend doesn't return/store fall back to the cached value.
+    expect(result.categories.SYSTEM).toBe(DEFAULT_PREFERENCES.categories.SYSTEM);
+    expect(result.sound).toBe(DEFAULT_PREFERENCES.sound);
+    expect(result.dndStart).toBe(DEFAULT_PREFERENCES.dndStart);
+  });
+
+  it('sends the category booleans to the settings endpoint on update', async () => {
+    mockAxiosInstance.patch.mockResolvedValue({ data: {} });
+
+    await notificationsAPI.updatePreferences('user-1', DEFAULT_PREFERENCES);
+
+    expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
+      '/user-1/settings',
+      expect.objectContaining({
+        appointment: true,
+        medication: true,
+        consultation: true,
+        alert: true,
+        message: true,
+        vaccination: true,
+        lostPet: true,
+        medicalRecord: true,
+        system: true,
+      })
+    );
+  });
+});

--- a/src/lib/api/notificationsAPI.ts
+++ b/src/lib/api/notificationsAPI.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { getApiBaseUrl } from './apiBaseUrl';
+import type { NotificationPreferences } from '@/types/notification';
 
 export type NotificationCategory =
   | 'APPOINTMENT'
@@ -45,6 +46,64 @@ export interface Notification {
 export interface RegisterDeviceTokenDto {
   token: string;
   platform?: string;
+}
+
+// The backend's notification_settings table only stores per-category
+// booleans (+ a global switch) — it has no columns for sound/vibration/
+// browserPush/DND, which stay client-only (localStorage). This maps
+// between that DTO and the frontend's NotificationPreferences.categories.
+export interface NotificationSettingsDto {
+  globalEnabled?: boolean;
+  appointment?: boolean;
+  medication?: boolean;
+  consultation?: boolean;
+  alert?: boolean;
+  message?: boolean;
+  vaccination?: boolean;
+  lostPet?: boolean;
+  medicalRecord?: boolean;
+  system?: boolean;
+}
+
+const CATEGORY_TO_SETTINGS_FIELD: Record<
+  keyof NotificationPreferences['categories'],
+  keyof Omit<NotificationSettingsDto, 'globalEnabled'>
+> = {
+  APPOINTMENT: 'appointment',
+  MEDICATION: 'medication',
+  CONSULTATION: 'consultation',
+  ALERT: 'alert',
+  MESSAGE: 'message',
+  VACCINATION: 'vaccination',
+  LOST_PET: 'lostPet',
+  MEDICAL_RECORD: 'medicalRecord',
+  SYSTEM: 'system',
+};
+
+function categoriesToSettingsDto(
+  categories: NotificationPreferences['categories']
+): NotificationSettingsDto {
+  const dto: NotificationSettingsDto = {};
+  (
+    Object.keys(CATEGORY_TO_SETTINGS_FIELD) as (keyof NotificationPreferences['categories'])[]
+  ).forEach((category) => {
+    dto[CATEGORY_TO_SETTINGS_FIELD[category]] = categories[category];
+  });
+  return dto;
+}
+
+function settingsDtoToCategories(
+  dto: NotificationSettingsDto,
+  fallback: NotificationPreferences['categories']
+): NotificationPreferences['categories'] {
+  const categories = { ...fallback };
+  (
+    Object.keys(CATEGORY_TO_SETTINGS_FIELD) as (keyof NotificationPreferences['categories'])[]
+  ).forEach((category) => {
+    const value = dto[CATEGORY_TO_SETTINGS_FIELD[category]];
+    if (typeof value === 'boolean') categories[category] = value;
+  });
+  return categories;
 }
 
 class NotificationsAPI {
@@ -93,6 +152,26 @@ class NotificationsAPI {
 
   async removeDeviceToken(userId: string, token: string): Promise<void> {
     await this.api.delete(`/${userId}/device-tokens/${token}`);
+  }
+
+  /**
+   * Fetches the server's category settings and merges them into `fallback`
+   * (the locally cached preferences), so client-only fields the backend
+   * doesn't store (sound, vibration, browserPush, DND) are preserved.
+   */
+  async getPreferences(
+    userId: string,
+    fallback: NotificationPreferences
+  ): Promise<NotificationPreferences> {
+    const response = await this.api.get<NotificationSettingsDto>(`/${userId}/settings`);
+    return {
+      ...fallback,
+      categories: settingsDtoToCategories(response.data, fallback.categories),
+    };
+  }
+
+  async updatePreferences(userId: string, preferences: NotificationPreferences): Promise<void> {
+    await this.api.patch(`/${userId}/settings`, categoriesToSettingsDto(preferences.categories));
   }
 }
 


### PR DESCRIPTION
closes #775

## Summary
`NotificationPreferencesPanel`'s toggles and "Save preferences" button gave the impression preferences were saved to the account, but `updatePreferences` only ever wrote to `localStorage` and "Save preferences" was a cosmetic 2s checkmark with no network call.

- `notificationsAPI`: added `getPreferences`/`updatePreferences`, backed by the existing `GET`/`PATCH /notifications/:userId/settings` endpoints. The backend's `notification_settings` table only stores per-category booleans (no columns for sound/vibration/browserPush/DND), so the mapping merges the backend's category flags onto the cached preferences and leaves the client-only fields as the localStorage-cached values.
- `NotificationContext`: hydrates preferences from the backend on login (falls back to the localStorage cache if the request fails), persists every `updatePreferences()` change to the backend in the background, and tracks a `preferencesSyncStatus` (`idle`/`saving`/`saved`/`error`) plus a `syncPreferences()` retry action.
- `handleIncoming` and the toast-subscription handler now read the live in-memory preferences via a ref instead of re-reading `localStorage` on every incoming notification.
- `NotificationPreferencesPanel`: "Save preferences" now calls `syncPreferences()` and reflects real saving/saved/error state, with a visible error message on failure instead of a silent optimistic no-op.
- Added tests for the settings ↔ preferences mapping (`notificationsAPI.test.ts`).
