### PR TITLE
fix: wallet security and validation improvements

### DIFF
--- a/src/components/Wallet/WalletDashboard.tsx
+++ b/src/components/Wallet/WalletDashboard.tsx
@@ -7,6 +7,8 @@ import {
   CheckCircle,
   Wallet,
   Plus,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import type { WalletAccount, WalletMonitoringData } from '../../types/wallet';
 import { formatBalance } from '../../utils/formatCurrency';
@@ -21,7 +23,7 @@ interface Props {
   onRefreshBalance: () => void;
   onFundTestnet: () => void;
   onAddWallet: () => void;
-  onDeleteWallet: (id: string) => void;
+  onDeleteWallet: (id: string, pin: string) => Promise<void>;
   isTestnet: boolean;
   loading: boolean;
 }
@@ -52,7 +54,10 @@ export default function WalletDashboard({
   loading,
 }: Props) {
   const [copied, setCopied] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [deleteStep, setDeleteStep] = useState<'initial' | 'pin' | 'confirm'>('initial');
+  const [deletePin, setDeletePin] = useState('');
+  const [showPin, setShowPin] = useState(false);
+  const [deleteAckUnverified, setDeleteAckUnverified] = useState(false);
 
   function copyAddress() {
     if (!selectedWallet) return;
@@ -288,35 +293,129 @@ export default function WalletDashboard({
 
           {/* Danger Zone */}
           <div className="bg-white rounded-xl shadow-sm border border-red-100 p-6">
-            <h3 className="font-semibold text-red-700 mb-2 text-sm">Danger Zone</h3>
-            {confirmDelete === selectedWallet.id ? (
-              <div className="flex items-center gap-3">
-                <p className="text-sm text-red-600">
-                  Remove &quot;{selectedWallet.label}&quot; from this device?
-                </p>
+            <h3 className="font-semibold text-red-700 mb-4 text-sm">Danger Zone</h3>
+
+            {deleteStep === 'initial' && (
+              <>
+                {!selectedWallet.backupVerified && (
+                  <div className="mb-4 flex items-start gap-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                    <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" />
+                    <span>
+                      <strong>Warning:</strong> This wallet has no verified backup. Deleting it will permanently destroy access to these funds.
+                    </span>
+                  </div>
+                )}
+                {accountData && xlmBalance && parseFloat(xlmBalance.balance) > 0 && (
+                  <div className="mb-4 flex items-start gap-3 text-sm text-orange-700 bg-orange-50 border border-orange-200 rounded-lg px-3 py-2">
+                    <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" />
+                    <span>
+                      <strong>Balance:</strong> This wallet holds {formatBalance(xlmBalance.balance)} XLM.
+                    </span>
+                  </div>
+                )}
                 <button
-                  onClick={() => {
-                    onDeleteWallet(selectedWallet.id);
-                    setConfirmDelete(null);
-                  }}
-                  className="px-3 py-1.5 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700"
+                  onClick={() => setDeleteStep('pin')}
+                  className="text-sm text-red-600 hover:underline"
                 >
-                  Confirm
+                  Remove wallet from this device
                 </button>
-                <button
-                  onClick={() => setConfirmDelete(null)}
-                  className="px-3 py-1.5 text-gray-600 text-sm rounded-lg border border-gray-300 hover:bg-gray-50"
-                >
-                  Cancel
-                </button>
+              </>
+            )}
+
+            {deleteStep === 'pin' && (
+              <div className="space-y-3">
+                {!selectedWallet.backupVerified && (
+                  <div className="flex items-start gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      id="ack-unverified"
+                      checked={deleteAckUnverified}
+                      onChange={(e) => setDeleteAckUnverified(e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <label htmlFor="ack-unverified" className="text-red-700">
+                      I understand this wallet has no verified backup and I will lose access to all funds.
+                    </label>
+                  </div>
+                )}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Enter PIN to confirm deletion
+                  </label>
+                  <div className="relative">
+                    <input
+                      type={showPin ? 'text' : 'password'}
+                      value={deletePin}
+                      onChange={(e) => setDeletePin(e.target.value)}
+                      placeholder="Enter PIN…"
+                      className="w-full px-3 py-2 pr-10 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPin((s) => !s)}
+                      className="absolute inset-y-0 right-0 px-3 text-gray-400 hover:text-gray-600"
+                    >
+                      {showPin ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      if (!selectedWallet.backupVerified && !deleteAckUnverified) return;
+                      setDeleteStep('confirm');
+                    }}
+                    disabled={!selectedWallet.backupVerified && !deleteAckUnverified}
+                    className="px-3 py-2 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Next
+                  </button>
+                  <button
+                    onClick={() => {
+                      setDeleteStep('initial');
+                      setDeletePin('');
+                      setDeleteAckUnverified(false);
+                      setShowPin(false);
+                    }}
+                    className="px-3 py-2 text-gray-600 text-sm rounded-lg border border-gray-300 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
               </div>
-            ) : (
-              <button
-                onClick={() => setConfirmDelete(selectedWallet.id)}
-                className="text-sm text-red-600 hover:underline"
-              >
-                Remove wallet from this device
-              </button>
+            )}
+
+            {deleteStep === 'confirm' && (
+              <div className="space-y-3">
+                <p className="text-sm text-red-600">
+                  Really remove &quot;{selectedWallet.label}&quot;? This cannot be undone.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      onDeleteWallet(selectedWallet.id, deletePin);
+                      setDeleteStep('initial');
+                      setDeletePin('');
+                      setDeleteAckUnverified(false);
+                      setShowPin(false);
+                    }}
+                    className="px-3 py-2 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700"
+                  >
+                    Confirm Deletion
+                  </button>
+                  <button
+                    onClick={() => {
+                      setDeleteStep('initial');
+                      setDeletePin('');
+                      setDeleteAckUnverified(false);
+                      setShowPin(false);
+                    }}
+                    className="px-3 py-2 text-gray-600 text-sm rounded-lg border border-gray-300 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
             )}
           </div>
         </>

--- a/src/components/Wallet/WalletSetup.tsx
+++ b/src/components/Wallet/WalletSetup.tsx
@@ -98,6 +98,7 @@ export default function WalletSetup({
   onClearError,
 }: Props) {
   const [tab, setTab] = useState<Tab>('create');
+  const [formError, setFormError] = useState<string | null>(null);
 
   // Create form
   const [createLabel, setCreateLabel] = useState('');
@@ -133,8 +134,12 @@ export default function WalletSetup({
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     onClearError();
+    setFormError(null);
     const err = validateCreate();
-    if (err) return;
+    if (err) {
+      setFormError(err);
+      return;
+    }
     try {
       await onCreateWallet(createLabel.trim(), createPin);
       setCreateSuccess(true);
@@ -149,8 +154,12 @@ export default function WalletSetup({
   async function handleImport(e: React.FormEvent) {
     e.preventDefault();
     onClearError();
+    setFormError(null);
     const err = validateImport();
-    if (err) return;
+    if (err) {
+      setFormError(err);
+      return;
+    }
     try {
       await onImportWallet(importSecretKey, importLabel.trim(), importPin);
       setImportSuccess(true);
@@ -183,10 +192,10 @@ export default function WalletSetup({
         ))}
       </div>
 
-      {error && (
+      {(error || formError) && (
         <div className="mb-4 flex items-center gap-2 bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">
           <AlertTriangle size={16} className="flex-shrink-0" />
-          {error}
+          {formError || error}
         </div>
       )}
 
@@ -227,9 +236,6 @@ export default function WalletSetup({
             label="Confirm PIN"
             placeholder="Re-enter PIN…"
           />
-          {createPin && createPinConfirm && createPin !== createPinConfirm && (
-            <p className="text-xs text-red-500">PINs do not match.</p>
-          )}
           <button
             type="submit"
             disabled={loading}
@@ -271,9 +277,6 @@ export default function WalletSetup({
             label="Confirm PIN"
             placeholder="Re-enter PIN…"
           />
-          {importPin && importPinConfirm && importPin !== importPinConfirm && (
-            <p className="text-xs text-red-500">PINs do not match.</p>
-          )}
           <button
             type="submit"
             disabled={loading}

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -127,12 +127,26 @@ export function useWallet() {
 
   // ─── Wallet deletion ───────────────────────────────────────────────────────
   const deleteWallet = useCallback(
-    (id: string) => {
-      walletService.deleteWallet(id);
-      const updated = walletService.getWallets();
-      setWallets(updated);
-      if (selectedWalletId === id) {
-        setSelectedWalletId(updated[0]?.id ?? null);
+    async (id: string, pin: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const wallet = walletService.getWallet(id);
+        if (!wallet) throw new Error('Wallet not found.');
+        const isValid = await walletService.verifyPin(wallet, pin);
+        if (!isValid) throw new Error('Invalid PIN.');
+        walletService.deleteWallet(id);
+        const updated = walletService.getWallets();
+        setWallets(updated);
+        if (selectedWalletId === id) {
+          setSelectedWalletId(updated[0]?.id ?? null);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Failed to delete wallet.';
+        setError(msg);
+        throw err;
+      } finally {
+        setLoading(false);
       }
     },
     [selectedWalletId]
@@ -206,12 +220,16 @@ export function useWallet() {
     async (pin: string): Promise<BackupData> => {
       if (!selectedWallet) throw new Error('No wallet selected.');
       const backup = await walletService.exportBackup(selectedWallet, pin);
-      walletService.markBackupVerified(selectedWallet.id);
-      setWallets(walletService.getWallets());
       return backup;
     },
     [selectedWallet]
   );
+
+  const markBackupAsVerified = useCallback(() => {
+    if (!selectedWallet) throw new Error('No wallet selected.');
+    walletService.markBackupVerified(selectedWallet.id);
+    setWallets(walletService.getWallets());
+  }, [selectedWallet]);
 
   const importBackup = useCallback(async (backup: BackupData, pin: string) => {
     setLoading(true);
@@ -270,6 +288,7 @@ export function useWallet() {
     setupMultiSig,
     removeSigner,
     exportBackup,
+    markBackupAsVerified,
     importBackup,
     fundTestnet,
   };

--- a/src/lib/wallet/walletService.ts
+++ b/src/lib/wallet/walletService.ts
@@ -309,6 +309,34 @@ class WalletService {
     return this.normalizeBroadcastResult(result);
   }
 
+  async importWallet(secretKey: string, label: string, pin: string): Promise<WalletAccount> {
+    const keypair = StellarSdk.Keypair.fromSecret(secretKey);
+    const publicKey = keypair.publicKey();
+
+    const existing = this.getWallets().find((w) => w.publicKey === publicKey);
+    if (existing) {
+      throw new Error(`This wallet is already added as "${existing.label}".`);
+    }
+
+    const { encryptedKey, iv, salt } = await encryptSecretKey(secretKey, pin);
+
+    const wallet: WalletAccount = {
+      id: `wallet_${randomUUID()}`,
+      publicKey,
+      encryptedSecretKey: encryptedKey,
+      iv,
+      salt,
+      label,
+      type: 'standard',
+      network: this.network,
+      createdAt: new Date().toISOString(),
+      backupVerified: false,
+    };
+
+    this.persistWallet(wallet);
+    return wallet;
+  }
+
   // ─── Backup & Recovery ────────────────────────────────────────────────────────
 
   async exportBackup(wallet: WalletAccount, pin: string): Promise<BackupData> {
@@ -340,6 +368,11 @@ class WalletService {
 
     // Verify PIN decrypts correctly
     await decryptSecretKey(backup.encryptedKey, backup.iv, backup.salt, pin);
+
+    const existing = this.getWallets().find((w) => w.publicKey === backup.publicKey);
+    if (existing) {
+      throw new Error(`This wallet is already added as "${existing.label}".`);
+    }
 
     const wallet: WalletAccount = {
       id: `wallet_${randomUUID()}`,


### PR DESCRIPTION
- Display all validation errors in WalletSetup form (empty name, short PIN)
- Add duplicate-wallet detection on import/restore to prevent adding same secret key multiple times
- Prevent premature backup verification marking - only mark verified after user confirms file save
- Require PIN re-verification before wallet deletion with additional safeguards for unverified backups
- Show balance warning when deleting wallet with funds

Closes #704, Closes #705, Closes #706, Closes #707