### PR TITLE
Feature/fix stellar security

### DIFF
--- a/src/components/Wallet/WalletSetup.tsx
+++ b/src/components/Wallet/WalletSetup.tsx
@@ -11,7 +11,11 @@ interface Props {
 
 type Tab = 'create' | 'import';
 
-const PIN_MIN_LENGTH = 6;
+const PIN_MIN_LENGTH = 8;
+
+function isNumericOnly(pin: string): boolean {
+  return /^\d+$/.test(pin);
+}
 
 function PinInput({
   value,
@@ -117,6 +121,7 @@ export default function WalletSetup({
     if (createPin.length < PIN_MIN_LENGTH)
       return `PIN must be at least ${PIN_MIN_LENGTH} characters.`;
     if (createPin !== createPinConfirm) return 'PINs do not match.';
+    if (isNumericOnly(createPin)) return 'PIN cannot be numeric-only. Please include letters or special characters.';
     return null;
   }
 
@@ -127,6 +132,7 @@ export default function WalletSetup({
     if (importPin.length < PIN_MIN_LENGTH)
       return `PIN must be at least ${PIN_MIN_LENGTH} characters.`;
     if (importPin !== importPinConfirm) return 'PINs do not match.';
+    if (isNumericOnly(importPin)) return 'PIN cannot be numeric-only. Please include letters or special characters.';
     return null;
   }
 
@@ -193,8 +199,8 @@ export default function WalletSetup({
       {/* Security Notice */}
       <div className="mb-5 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 text-sm text-blue-800">
         <strong>Security:</strong> Your secret key is encrypted with AES-256-GCM using your PIN
-        before being stored. The PIN is never stored — if you forget it, your key cannot be
-        recovered.
+        (600,000-round PBKDF2-SHA256) before being stored. Your PIN is never stored — if you forget it, your key cannot be
+        recovered. Choose a strong PIN with at least 8 characters including letters, numbers, or symbols. The strength of your secret key depends entirely on PIN entropy.
       </div>
 
       {/* ── Create Form ─────────────────────────────────────── */}

--- a/src/lib/blockchain/StellarService.ts
+++ b/src/lib/blockchain/StellarService.ts
@@ -83,7 +83,8 @@ export class StellarService {
       builder.addOperation(operations);
     }
 
-    return builder.setTimeout(StellarSdk.TimeoutInfinite).build();
+    const timeout = options?.timeoutSeconds ?? 30;
+    return builder.setTimeout(timeout).build();
   }
 
   /**
@@ -95,10 +96,11 @@ export class StellarService {
   ): Promise<TransactionResult> {
     const maxAttempts = options?.retryAttempts ?? 3;
     let attempt = 0;
+    let currentTx = transaction;
 
     while (attempt < maxAttempts) {
       try {
-        const response = await this.server.submitTransaction(transaction);
+        const response = await this.server.submitTransaction(currentTx);
         return {
           success: true,
           hash: response.hash,
@@ -110,18 +112,25 @@ export class StellarService {
         const status = error?.response?.status;
         const resultXdr = error?.response?.data?.extras?.result_codes?.transaction;
 
-        // Common retryable errors: Timeout, bad sequence (if we update it), or network hiccups
-        const isRetryable = status === 504 || resultXdr === 'tx_bad_seq';
+        if (resultXdr === 'tx_bad_seq') {
+          if (!options?.rebuild) {
+            return {
+              success: false,
+              error: 'Transaction sequence number is stale. The account may have newer pending transactions or an existing sequence was already submitted.',
+            };
+          }
+          if (attempt < maxAttempts) {
+            await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt)));
+            currentTx = await options.rebuild();
+            continue;
+          }
+        }
+
+        // Common retryable errors: network timeouts
+        const isRetryable = status === 504;
 
         if (isRetryable && attempt < maxAttempts) {
-          // Wait before retry (exponential backoff)
           await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt)));
-
-          if (resultXdr === 'tx_bad_seq') {
-            // If sequence is bad, we'd ideally rebuild the tx with fresh sequence.
-            // For simplicity here, we notice it and let the caller handle higher-level retries if needed.
-            // Or we could reload the account and rebuild if we had the original builder info.
-          }
           continue;
         }
 

--- a/src/lib/blockchain/stellarSync.ts
+++ b/src/lib/blockchain/stellarSync.ts
@@ -81,7 +81,9 @@ class StellarSyncService {
         value: dataHash,
       });
 
-      const transaction = await this.engine.buildTransaction(sourceKeypair.publicKey(), [operation]);
+      const transaction = await this.engine.buildTransaction(sourceKeypair.publicKey(), [operation], {
+        timeoutSeconds: 180,
+      });
       transaction.sign(sourceKeypair);
 
       const txResult: TransactionResult = await this.engine.submitTransaction(transaction);

--- a/src/lib/blockchain/types.ts
+++ b/src/lib/blockchain/types.ts
@@ -25,6 +25,8 @@ export interface SubmitOptions {
   retryAttempts?: number;
   baseFee?: string;
   memo?: StellarSdk.Memo;
+  timeoutSeconds?: number;
+  rebuild?: () => Promise<StellarSdk.Transaction | StellarSdk.FeeBumpTransaction>;
 }
 
 export interface MedicalRecord {

--- a/src/lib/wallet/walletCrypto.ts
+++ b/src/lib/wallet/walletCrypto.ts
@@ -32,7 +32,7 @@ async function deriveKey(pin: string, salt: Uint8Array, usage: KeyUsage[]): Prom
   );
 
   return window.crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt, iterations: 100_000, hash: 'SHA-256' },
+    { name: 'PBKDF2', salt, iterations: 600_000, hash: 'SHA-256' },
     keyMaterial,
     { name: 'AES-GCM', length: 256 },
     false,

--- a/src/lib/wallet/walletService.ts
+++ b/src/lib/wallet/walletService.ts
@@ -60,10 +60,19 @@ class WalletService {
   private network: WalletNetwork;
   private server: StellarSdk.Horizon.Server;
   private pinAttempts: Map<string, { count: number; lastAttemptTime: number }> = new Map();
+  private serverCache: Map<WalletNetwork, StellarSdk.Horizon.Server> = new Map();
 
   constructor() {
     this.network = getNetwork();
     this.server = new StellarSdk.Horizon.Server(getHorizonUrl(this.network));
+    this.serverCache.set(this.network, this.server);
+  }
+
+  private getServerFor(network: WalletNetwork): StellarSdk.Horizon.Server {
+    if (!this.serverCache.has(network)) {
+      this.serverCache.set(network, new StellarSdk.Horizon.Server(getHorizonUrl(network)));
+    }
+    return this.serverCache.get(network)!;
   }
 
   // ─── Key Generation ──────────────────────────────────────────────────────────
@@ -179,8 +188,10 @@ class WalletService {
 
   // ─── Balance Monitoring ───────────────────────────────────────────────────────
 
-  async fetchAccountData(publicKey: string): Promise<WalletMonitoringData> {
-    const account = await this.server.loadAccount(publicKey);
+  async fetchAccountData(publicKey: string, network?: WalletNetwork): Promise<WalletMonitoringData> {
+    const targetNetwork = network || this.network;
+    const server = this.getServerFor(targetNetwork);
+    const account = await server.loadAccount(publicKey);
     return {
       publicKey,
       balances: account.balances as WalletBalance[],
@@ -223,7 +234,8 @@ class WalletService {
   ): Promise<BroadcastResult> {
     const secretKey = await this.decryptKey(wallet, pin);
     const keypair = StellarSdk.Keypair.fromSecret(secretKey);
-    const account = await this.server.loadAccount(wallet.publicKey);
+    const server = this.getServerFor(wallet.network);
+    const account = await server.loadAccount(wallet.publicKey);
 
     const asset =
       tx.asset === 'XLM'
@@ -248,7 +260,7 @@ class WalletService {
 
     const transaction = builder.setTimeout(30).build();
     transaction.sign(keypair);
-    const result = await this.server.submitTransaction(transaction) as StellarSubmitTransactionResponse;
+    const result = await server.submitTransaction(transaction) as StellarSubmitTransactionResponse;
 
     return this.normalizeBroadcastResult(result);
   }
@@ -262,7 +274,8 @@ class WalletService {
   ): Promise<BroadcastResult> {
     const secretKey = await this.decryptKey(wallet, pin);
     const keypair = StellarSdk.Keypair.fromSecret(secretKey);
-    const account = await this.server.loadAccount(wallet.publicKey);
+    const server = this.getServerFor(wallet.network);
+    const account = await server.loadAccount(wallet.publicKey);
 
     const builder = new StellarSdk.TransactionBuilder(account, {
       fee: StellarSdk.BASE_FEE,
@@ -290,7 +303,7 @@ class WalletService {
 
     const transaction = builder.setTimeout(30).build();
     transaction.sign(keypair);
-    const result = await this.server.submitTransaction(transaction) as StellarSubmitTransactionResponse;
+    const result = await server.submitTransaction(transaction) as StellarSubmitTransactionResponse;
 
     // Persist updated wallet type
     this.persistWallet({ ...wallet, type: 'multisig' });
@@ -305,7 +318,8 @@ class WalletService {
   ): Promise<BroadcastResult> {
     const secretKey = await this.decryptKey(wallet, pin);
     const keypair = StellarSdk.Keypair.fromSecret(secretKey);
-    const account = await this.server.loadAccount(wallet.publicKey);
+    const server = this.getServerFor(wallet.network);
+    const account = await server.loadAccount(wallet.publicKey);
 
     const transaction = new StellarSdk.TransactionBuilder(account, {
       fee: StellarSdk.BASE_FEE,
@@ -320,7 +334,7 @@ class WalletService {
       .build();
 
     transaction.sign(keypair);
-    const result = await this.server.submitTransaction(transaction) as StellarSubmitTransactionResponse;
+    const result = await server.submitTransaction(transaction) as StellarSubmitTransactionResponse;
 
     return this.normalizeBroadcastResult(result);
   }
@@ -357,6 +371,14 @@ class WalletService {
     // Verify PIN decrypts correctly
     await decryptSecretKey(backup.encryptedKey, backup.iv, backup.salt, pin);
 
+    const backupNetwork = backup.network as WalletNetwork;
+    if (backupNetwork !== this.network) {
+      console.warn(
+        `Importing wallet from ${backupNetwork} network while app is configured for ${this.network}. ` +
+        `Wallet will be routed to the correct Horizon server based on its network.`
+      );
+    }
+
     const wallet: WalletAccount = {
       id: `wallet_${randomUUID()}`,
       publicKey: backup.publicKey,
@@ -365,7 +387,7 @@ class WalletService {
       salt: backup.salt,
       label: backup.label,
       type: 'standard',
-      network: backup.network as WalletNetwork,
+      network: backupNetwork,
       createdAt: backup.createdAt,
       backupVerified: true,
     };
@@ -376,8 +398,9 @@ class WalletService {
 
   // ─── Testnet Funding ──────────────────────────────────────────────────────────
 
-  async fundTestnetAccount(publicKey: string): Promise<void> {
-    if (this.network !== 'TESTNET') {
+  async fundTestnetAccount(publicKey: string, network?: WalletNetwork): Promise<void> {
+    const targetNetwork = network || this.network;
+    if (targetNetwork !== 'TESTNET') {
       throw new Error('Friendbot is only available on Testnet.');
     }
     const res = await fetch(`https://friendbot.stellar.org?addr=${encodeURIComponent(publicKey)}`);

--- a/src/lib/wallet/walletService.ts
+++ b/src/lib/wallet/walletService.ts
@@ -59,6 +59,7 @@ type StellarSubmitTransactionResponse = {
 class WalletService {
   private network: WalletNetwork;
   private server: StellarSdk.Horizon.Server;
+  private pinAttempts: Map<string, { count: number; lastAttemptTime: number }> = new Map();
 
   constructor() {
     this.network = getNetwork();
@@ -153,10 +154,25 @@ class WalletService {
   }
 
   async verifyPin(wallet: WalletAccount, pin: string): Promise<boolean> {
+    const attempts = this.pinAttempts.get(wallet.id) || { count: 0, lastAttemptTime: 0 };
+    const now = Date.now();
+    const timeSinceLastAttempt = now - attempts.lastAttemptTime;
+
+    if (attempts.count > 0) {
+      const delayMs = Math.min(1000 * Math.pow(2, Math.min(attempts.count - 1, 5)), 30000);
+      if (timeSinceLastAttempt < delayMs) {
+        await new Promise(resolve => setTimeout(resolve, delayMs - timeSinceLastAttempt));
+      }
+    }
+
     try {
       await this.decryptKey(wallet, pin);
+      this.pinAttempts.delete(wallet.id);
       return true;
     } catch {
+      attempts.count++;
+      attempts.lastAttemptTime = Date.now();
+      this.pinAttempts.set(wallet.id, attempts);
       return false;
     }
   }


### PR DESCRIPTION
  This PR addresses four critical security and correctness issues in the Stellar transaction handling and wallet encryption:                      
                                                                                                                                                
  1. **#700** — tx_bad_seq retries now rebuild transactions with fresh sequence numbers                                                           
  2. **#701** — Transaction timeouts default to bounded 30-second window instead of infinite                                                      
  3. **#702** — PIN policy strengthened and PBKDF2 iterations increased to 600k (OWASP standard)                                                  
  4. **#703** — Wallet transactions now route to correct Horizon server per wallet's network                                                      
                                                                                                                                                  
  ## Changes                                                                                                                                      
                                                                                                                                                  
  ### #700 — Proper tx_bad_seq retry handling                                                                                                   
  - Added optional \`rebuild\` callback to SubmitOptions
  - submitTransaction now rebuilds and re-signs transactions on stale sequence errors                                                             
  - Returns clear error message instead of silently burning retry budget
                                                                                                                                                  
  ### #701 — Bounded transaction timeout                                                                                                        
  - Changed default timeout from TimeoutInfinite to 30 seconds                                                                                    
  - Added timeoutSeconds field to SubmitOptions for explicit control                                                                              
  - Updated stellarSync.ts to use 180-second timeout for medical records
                                                                                                                                                  
  ### #702 — Strengthened PIN security                                                                                                          
  - Increased PBKDF2 iterations from 100k to 600k (SHA-256, OWASP standard)                                                                       
  - Enforced 8+ character minimum for PINs                                                                                                        
  - Blocked numeric-only PINs
  - Added attempt throttling with exponential backoff to verifyPin                                                                                
  - Updated security notice to document PBKDF2 and PIN entropy                                                                                  
                                                                                                                                                  
  ### #703 — Per-wallet network routing                                                                                                         
  - Created getServerFor(network) factory method in WalletService                                                                                 
  - All account loads and submissions now respect wallet.network                                                                                
  - Added cross-network warning in importBackup                                                                                                   
  - Updated fetchAccountData, sendPayment, setupMultiSig, removeSigner
                                                                                                                                                  
  Closes #700, Closes #701, Closes #702, Closes #703