### PR TITLE
fix: resolve issues #758, #759, #760, #761

### DIFF
--- a/src/components/Appointments/AppointmentCard.tsx
+++ b/src/components/Appointments/AppointmentCard.tsx
@@ -28,7 +28,7 @@ export default function AppointmentCard({ appointment, vetName, petName }: Appoi
       <div className="flex items-start justify-between mb-3">
         <div>
           <h3 className="font-bold text-blue-900 group-hover:text-blue-600 transition-colors uppercase text-xs tracking-wider">
-            {appointment.appointment_type}
+            {appointment.appointmentType}
           </h3>
           <p className="text-sm font-semibold text-gray-800">{petName}</p>
         </div>
@@ -43,7 +43,7 @@ export default function AppointmentCard({ appointment, vetName, petName }: Appoi
       <div className="space-y-2">
         <div className="flex items-center gap-2 text-xs text-gray-500">
           <Clock className="w-3.5 h-3.5" />
-          {new Date(appointment.scheduled_at).toLocaleTimeString([], {
+          {new Date(appointment.scheduledAt).toLocaleTimeString([], {
             hour: '2-digit',
             minute: '2-digit',
           })}{' '}

--- a/src/components/Appointments/BookingModal.tsx
+++ b/src/components/Appointments/BookingModal.tsx
@@ -57,9 +57,9 @@ export default function BookingModal({ onClose }: BookingModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const [formData, setFormData] = useState({
-    pet_id: '',
-    vet_id: '',
-    appointment_type: 'Checkup' as AppointmentType,
+    petId: '',
+    vetId: '',
+    appointmentType: 'Checkup' as AppointmentType,
     date: '',
     time: '09:00',
     notes: '',
@@ -70,8 +70,8 @@ export default function BookingModal({ onClose }: BookingModalProps) {
 
   const validate = () => {
     const next: Record<string, string> = {};
-    if (!formData.pet_id) next.pet_id = 'Please select a pet';
-    if (!formData.vet_id) next.vet_id = 'Please select a vet';
+    if (!formData.petId) next.petId = 'Please select a pet';
+    if (!formData.vetId) next.vetId = 'Please select a vet';
     if (!formData.date) next.date = 'Please pick a date';
     setErrors(next);
     return Object.keys(next).length === 0;
@@ -88,9 +88,9 @@ export default function BookingModal({ onClose }: BookingModalProps) {
     setSubmitError(null);
     try {
       await appointmentsAPI.createAppointment({
-        pet_id: formData.pet_id,
-        vet_id: formData.vet_id,
-        appointment_type: formData.appointment_type,
+        petId: formData.petId,
+        vetId: formData.vetId,
+        appointmentType: formData.appointmentType,
         date: formData.date,
         time: formData.time,
         notes: formData.notes || undefined,
@@ -220,18 +220,18 @@ export default function BookingModal({ onClose }: BookingModalProps) {
             label="Select pet"
             options={PET_OPTIONS}
             placeholder="Choose your pet"
-            value={formData.pet_id}
-            onChange={(e) => setFormData((f) => ({ ...f, pet_id: e.target.value }))}
+            value={formData.petId}
+            onChange={(e) => setFormData((f) => ({ ...f, petId: e.target.value }))}
             required
             aria-required="true"
-            error={errors.pet_id}
+            error={errors.petId}
           />
 
           <TouchPillGroup
             label="Appointment type"
             options={APPOINTMENT_TYPES}
-            value={formData.appointment_type}
-            onChange={(v) => setFormData((f) => ({ ...f, appointment_type: v }))}
+            value={formData.appointmentType}
+            onChange={(v) => setFormData((f) => ({ ...f, appointmentType: v }))}
           />
 
           <div className="grid grid-cols-2 gap-3">
@@ -256,11 +256,11 @@ export default function BookingModal({ onClose }: BookingModalProps) {
             label="Veterinarian"
             options={VET_OPTIONS}
             placeholder="Select a vet"
-            value={formData.vet_id}
-            onChange={(e) => setFormData((f) => ({ ...f, vet_id: e.target.value }))}
+            value={formData.vetId}
+            onChange={(e) => setFormData((f) => ({ ...f, vetId: e.target.value }))}
             required
             aria-required="true"
-            error={errors.vet_id}
+            error={errors.vetId}
           />
 
           <TouchTextarea

--- a/src/components/Settings/AccountSettings.module.css
+++ b/src/components/Settings/AccountSettings.module.css
@@ -69,6 +69,22 @@
   border-color: #bbf7d0;
 }
 
+.sessionItem.currentSession {
+  opacity: 1;
+  background-color: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.currentBadge {
+  display: inline-block;
+  padding: 2px 8px;
+  background-color: #dbeafe;
+  color: #1d4ed8;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
 .sessionInfo {
   flex: 1;
 }

--- a/src/components/Settings/AccountSettings.tsx
+++ b/src/components/Settings/AccountSettings.tsx
@@ -12,6 +12,8 @@ interface Session {
   expiresAt: string;
   lastActivityAt?: string;
   isActive: boolean;
+  /** True when this session corresponds to the browser currently viewing this page. */
+  isCurrentSession: boolean;
 }
 
 interface AccountSettingsProps {
@@ -52,7 +54,7 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
   const [successMessage, setSuccessMessage] = useState('');
 
   const handleRevokeSession = async (sessionId: string) => {
-    const currentSession = sessions.find((s) => s.isActive);
+    const currentSession = sessions.find((s) => s.isCurrentSession);
     if (!currentSession) return;
 
     const isSelfRevoke = sessionId === currentSession.id;
@@ -77,7 +79,7 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
   };
 
   const handleRevokeOthers = async () => {
-    const currentSession = sessions.find((s) => s.isActive);
+    const currentSession = sessions.find((s) => s.isCurrentSession);
     if (!currentSession) return;
 
     setIsSubmitting(true);
@@ -205,11 +207,14 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
                 {sessions.map((session) => (
                   <div
                     key={session.id}
-                    className={`${styles.sessionItem} ${session.isActive ? styles.active : ''}`}
+                    className={`${styles.sessionItem} ${session.isActive ? styles.active : ''} ${session.isCurrentSession ? styles.currentSession : ''}`}
                   >
                     <div className={styles.sessionInfo}>
                       <div className={styles.deviceName}>
                         {getDeviceName(session)}
+                        {session.isCurrentSession && (
+                          <span className={styles.currentBadge}>This device</span>
+                        )}
                         {!session.isActive && <span className={styles.badge}>Revoked</span>}
                       </div>
                       <div className={styles.sessionDetails}>

--- a/src/components/Wallet/WalletBackup.tsx
+++ b/src/components/Wallet/WalletBackup.tsx
@@ -1,18 +1,22 @@
 import React, { useState } from 'react';
 import { Download, ShieldCheck, AlertTriangle, Eye, EyeOff, CheckCircle } from 'lucide-react';
 import type { WalletAccount, BackupData } from '../../types/wallet';
+import { walletAPI } from '../../lib/api/walletAPI';
 
 interface Props {
   wallet: WalletAccount | null;
+  /** walletId on the server, required for server-side backup storage */
+  serverWalletId?: string;
   onExportBackup: (pin: string) => Promise<BackupData>;
 }
 
-export default function WalletBackup({ wallet, onExportBackup }: Props) {
+export default function WalletBackup({ wallet, serverWalletId, onExportBackup }: Props) {
   const [pin, setPin] = useState('');
   const [showPin, setShowPin] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [exported, setExported] = useState(false);
+  const [serverBackupDone, setServerBackupDone] = useState(false);
 
   if (!wallet) {
     return (
@@ -40,6 +44,18 @@ export default function WalletBackup({ wallet, onExportBackup }: Props) {
       URL.revokeObjectURL(url);
 
       setExported(true);
+
+      // Also store an encrypted copy on the server if we have a server wallet id.
+      // The backup payload contains only the encrypted key — the server never sees plaintext.
+      if (serverWalletId) {
+        try {
+          await walletAPI.storeBackup(serverWalletId, backup);
+          setServerBackupDone(true);
+        } catch (serverErr) {
+          console.warn('Server-side backup failed (local backup was still saved):', serverErr);
+        }
+      }
+
       setPin('');
     } catch (err) {
       setError(
@@ -135,7 +151,9 @@ export default function WalletBackup({ wallet, onExportBackup }: Props) {
         {exported && (
           <div className="flex items-center gap-2 text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2">
             <CheckCircle size={15} />
-            Backup downloaded. Store it in a secure location.
+            {serverBackupDone
+              ? 'Backup downloaded and saved to server. Store the local file in a secure location as well.'
+              : 'Backup downloaded. Store it in a secure location.'}
           </div>
         )}
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { getApiBaseUrl } from '../lib/api/apiBaseUrl';
+import { twoFactorAPI } from '../lib/api/twoFactorAPI';
 
 export interface User {
   id: string;
@@ -256,11 +257,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     clearError();
 
     try {
-      const data = await makeRequest('/auth/2fa/verify', {
-        method: 'POST',
-        body: JSON.stringify({ email, password, token: totpToken }),
-      });
-
+      const data = await twoFactorAPI.verify(email, password, totpToken);
       setAuth(data.user, {
         accessToken: data.accessToken,
         refreshToken: data.refreshToken,
@@ -282,11 +279,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     clearError();
 
     try {
-      const data = await makeRequest('/auth/2fa/recover', {
-        method: 'POST',
-        body: JSON.stringify({ email, password, backupCode }),
-      });
-
+      const data = await twoFactorAPI.recover(email, password, backupCode);
       setAuth(data.user, {
         accessToken: data.accessToken,
         refreshToken: data.refreshToken,

--- a/src/lib/api/appointmentsAPI.ts
+++ b/src/lib/api/appointmentsAPI.ts
@@ -55,16 +55,16 @@ const TYPE_MAP: Record<string, AppointmentType> = {
 function mapAppointment(item: BackendAppointment): UpcomingAppointmentView {
   const appointment: Appointment = {
     id: item.id,
-    pet_id: item.petId,
-    vet_id: item.vetClinicId,
-    appointment_type: TYPE_MAP[item.type] || 'Consultation',
-    scheduled_at: item.scheduledDate,
+    petId: item.petId,
+    vetId: item.vetClinicId,
+    appointmentType: TYPE_MAP[item.type] || 'Consultation',
+    scheduledAt: item.scheduledDate,
     duration: item.duration ?? 30,
     status: STATUS_MAP[item.status] || 'Scheduled',
     notes: item.notes,
-    reminder_sent: false,
-    created_at: item.createdAt,
-    updated_at: item.updatedAt,
+    reminderSent: false,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
   };
 
   return {
@@ -72,6 +72,15 @@ function mapAppointment(item: BackendAppointment): UpcomingAppointmentView {
     petName: item.pet?.name || 'Unknown pet',
     vetName: item.veterinarianName || item.vetClinic?.name || 'Veterinarian',
   };
+}
+
+export interface CreateAppointmentDto {
+  petId: string;
+  vetId: string;
+  appointmentType: AppointmentType;
+  date: string;
+  time: string;
+  notes?: string;
 }
 
 class AppointmentsAPI {
@@ -97,6 +106,19 @@ class AppointmentsAPI {
   async getUpcomingAppointments(): Promise<UpcomingAppointmentView[]> {
     const response = await this.api.get<BackendAppointment[]>('/upcoming');
     return response.data.map(mapAppointment);
+  }
+
+  async createAppointment(dto: CreateAppointmentDto): Promise<Appointment> {
+    // Map camelCase DTO to the backend's expected shape
+    const payload = {
+      petId: dto.petId,
+      vetClinicId: dto.vetId,
+      type: dto.appointmentType.toUpperCase(),
+      scheduledDate: `${dto.date}T${dto.time}:00`,
+      notes: dto.notes,
+    };
+    const response = await this.api.post<BackendAppointment>('/', payload);
+    return mapAppointment(response.data).appointment;
   }
 }
 

--- a/src/lib/api/twoFactorAPI.ts
+++ b/src/lib/api/twoFactorAPI.ts
@@ -12,6 +12,26 @@ export interface TwoFactorStatusResponse {
   backupCodesCount: number;
 }
 
+/** Shared response shape for /auth/2fa/verify and /auth/2fa/recover. */
+export interface TwoFactorAuthResponse {
+  user: {
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+    phone?: string;
+    avatarUrl?: string;
+    emailVerified: boolean;
+    phoneVerified: boolean;
+    isVerified: boolean;
+    isActive: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+  accessToken: string;
+  refreshToken: string;
+}
+
 class TwoFactorAPI {
   private api: AxiosInstance;
 
@@ -49,8 +69,8 @@ class TwoFactorAPI {
     await this.api.post('/disable', { token: totpToken });
   }
 
-  async verify(email: string, password: string, totpToken: string) {
-    const response = await this.api.post('/verify', { email, password, token: totpToken });
+  async verify(email: string, password: string, totpToken: string): Promise<TwoFactorAuthResponse> {
+    const response = await this.api.post<TwoFactorAuthResponse>('/verify', { email, password, token: totpToken });
     return response.data;
   }
 
@@ -59,8 +79,8 @@ class TwoFactorAPI {
     return response.data;
   }
 
-  async recover(email: string, password: string, backupCode: string) {
-    const response = await this.api.post('/recover', { email, password, backupCode });
+  async recover(email: string, password: string, backupCode: string): Promise<TwoFactorAuthResponse> {
+    const response = await this.api.post<TwoFactorAuthResponse>('/recover', { email, password, backupCode });
     return response.data;
   }
 }

--- a/src/lib/api/userAPI.ts
+++ b/src/lib/api/userAPI.ts
@@ -105,6 +105,10 @@ export interface UserSession {
   expiresAt: string;
   lastActivityAt?: string;
   isActive: boolean;
+  /** True when this session corresponds to the browser making the current request.
+   *  Populated server-side by comparing the session id embedded in the access token
+   *  against each listed session, or derived client-side when the backend cannot provide it. */
+  isCurrentSession: boolean;
   createdAt: string;
 }
 
@@ -306,8 +310,36 @@ class UserManagementAPI {
   }
 
   async getAllSessions(): Promise<UserSession[]> {
-    const response = await this.api.get('/me/sessions/all');
-    return response.data;
+    const response = await this.api.get<UserSession[]>('/me/sessions/all');
+    const sessions: UserSession[] = response.data;
+
+    // If the backend already populates isCurrentSession, use it as-is.
+    // Otherwise, derive it client-side from the session id embedded in the access token.
+    const alreadyFlagged = sessions.some((s) => s.isCurrentSession === true);
+    if (!alreadyFlagged) {
+      const currentSessionId = this.extractSessionIdFromToken();
+      return sessions.map((s) => ({
+        ...s,
+        isCurrentSession: currentSessionId ? s.id === currentSessionId : false,
+      }));
+    }
+
+    return sessions;
+  }
+
+  /** Decode the access token (without verifying signature) to extract the session id claim. */
+  private extractSessionIdFromToken(): string | null {
+    const token = this.getAccessToken();
+    if (!token) return null;
+    try {
+      const payloadBase64 = token.split('.')[1];
+      if (!payloadBase64) return null;
+      const payload = JSON.parse(atob(payloadBase64.replace(/-/g, '+').replace(/_/g, '/')));
+      // Common JWT claim names for session id
+      return payload.sessionId ?? payload.session_id ?? payload.sid ?? null;
+    } catch {
+      return null;
+    }
   }
 
   async revokeSession(sessionId: string): Promise<void> {

--- a/src/lib/wallet/walletService.ts
+++ b/src/lib/wallet/walletService.ts
@@ -2,6 +2,7 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { encryptSecretKey, decryptSecretKey, computeChecksum } from './walletCrypto';
 import { getStellarNetwork } from '../blockchain/network';
 import { randomUUID } from 'crypto';
+import { walletAPI } from '../api/walletAPI';
 import type {
   WalletAccount,
   WalletBalance,
@@ -113,6 +114,12 @@ class WalletService {
     };
 
     this.persistWallet(wallet);
+
+    // Register the public key with the backend (fire-and-forget; never sends secret key)
+    walletAPI.registerWallet(publicKey, label, this.network).catch((err) => {
+      console.warn('Failed to register wallet with backend:', err);
+    });
+
     return wallet;
   }
 
@@ -394,6 +401,12 @@ class WalletService {
     };
 
     this.persistWallet(wallet);
+
+    // Register the restored public key with the backend (fire-and-forget; never sends secret key)
+    walletAPI.registerWallet(backup.publicKey, backup.label, backupNetwork).catch((err) => {
+      console.warn('Failed to register imported wallet with backend:', err);
+    });
+
     return wallet;
   }
 

--- a/src/pages/account-settings.tsx
+++ b/src/pages/account-settings.tsx
@@ -44,7 +44,7 @@ export default function AccountSettingsPage() {
   }, [router]);
 
   const handleRevokeSession = async (sessionId: string) => {
-    const currentSession = sessions.find((s) => s.isActive);
+    const currentSession = sessions.find((s) => s.isCurrentSession);
     if (!currentSession) {
       setError('Unable to determine current session');
       return;

--- a/src/types/appointments.ts
+++ b/src/types/appointments.ts
@@ -9,18 +9,18 @@ export type AppointmentStatus = 'Scheduled' | 'Completed' | 'Cancelled' | 'No-Sh
 
 export interface Appointment {
   id: string;
-  pet_id: string;
-  vet_id: string;
-  appointment_type: AppointmentType;
-  scheduled_at: string; // ISO string
+  petId: string;
+  vetId: string;
+  appointmentType: AppointmentType;
+  scheduledAt: string; // ISO string
   duration: number; // in minutes
   status: AppointmentStatus;
   notes?: string;
-  reminder_sent: boolean;
-  is_recurring?: boolean;
-  recurrence_pattern?: string;
-  created_at: string;
-  updated_at: string;
+  reminderSent: boolean;
+  isRecurring?: boolean;
+  recurrencePattern?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface Vet {
@@ -31,17 +31,17 @@ export interface Vet {
 }
 
 export interface Availability {
-  vet_id: string;
-  day_of_week: number; // 0-6
-  start_time: string; // HH:mm
-  end_time: string; // HH:mm
-  is_active: boolean;
+  vetId: string;
+  dayOfWeek: number; // 0-6
+  startTime: string; // HH:mm
+  endTime: string; // HH:mm
+  isActive: boolean;
 }
 
 export interface WaitlistEntry {
   id: string;
-  pet_id: string;
-  preferred_type: AppointmentType;
-  preferred_vet_id?: string;
-  created_at: string;
+  petId: string;
+  preferredType: AppointmentType;
+  preferredVetId?: string;
+  createdAt: string;
 }


### PR DESCRIPTION
## Issue #758 — Appointment type snake_case → camelCase

Problem: src/types/appointments.ts used snake_case field names (pet_id, vet_id, appointment_type, scheduled_at, reminder_sent, is_recurring, recurrence_pattern, created_at, updated_at) while every other domain type in the codebase (Pet, UserProfile, Transaction, etc.) uses camelCase, matching the NestJS/TypeORM JSON API convention.

Fix:
- Renamed all snake_case fields in the Appointment interface to camelCase: pet_id → petId, vet_id → vetId, appointment_type → appointmentType, scheduled_at → scheduledAt, reminder_sent → reminderSent, is_recurring → isRecurring, recurrence_pattern → recurrencePattern, created_at → createdAt, updated_at → updatedAt.
- Also renamed Availability and WaitlistEntry snake_case fields.
- Updated AppointmentCard.tsx to reference appointment.appointmentType and appointment.scheduledAt instead of appointment_type / scheduled_at.
- Updated BookingModal.tsx form state keys (pet_id → petId, vet_id → vetId, appointment_type → appointmentType) and all downstream references.
- Updated appointmentsAPI.ts mapAppointment() to populate camelCase fields and added the missing CreateAppointmentDto + createAppointment() method that BookingModal was already calling.

Files changed: src/types/appointments.ts, src/components/Appointments/ AppointmentCard.tsx, src/components/Appointments/BookingModal.tsx, src/lib/api/appointmentsAPI.ts

Closes #758

---

## Issue #759 — twoFactorAPI.verify/recover were dead code, AuthContext duplicated them

Problem: twoFactorAPI.verify() and twoFactorAPI.recover() existed and called POST /auth/2fa/verify and POST /auth/2fa/recover, but AuthContext.loginWith2FA and AuthContext.recoverWith2FA independently re-implemented the exact same requests via its own makeRequest() helper. Two separate code paths for the same endpoints meant they could silently drift out of sync on a backend contract change. Neither twoFactorAPI method was typed — they returned any — so the assumption that the response contains data.user / data.accessToken / data.refreshToken was unverifiable at compile time.

Fix:
- Added TwoFactorAuthResponse interface to twoFactorAPI.ts, typed as { user, accessToken, refreshToken } — the shared response shape for both endpoints.
- Updated twoFactorAPI.verify() and twoFactorAPI.recover() return types to Promise<TwoFactorAuthResponse>.
- Replaced the duplicate inline fetch logic in AuthContext.loginWith2FA and AuthContext.recoverWith2FA with direct calls to twoFactorAPI.verify() and twoFactorAPI.recover(). There is now exactly one code path per endpoint.
- Added import { twoFactorAPI } to AuthContext.tsx.

Files changed: src/lib/api/twoFactorAPI.ts, src/contexts/AuthContext.tsx

Closes #759

---

## Issue #760 — walletAPI.ts was entirely unused; no wallet ever registered with backend

Problem: src/lib/api/walletAPI.ts was a fully implemented client for server-side wallet management (registerWallet, getWallets, updateWallet, deleteWallet, storeBackup, getBackup, getWalletTransactions) but was imported by zero files. Wallets created via walletService.createWallet() and restored via walletService.importBackup() only lived in localStorage. The backend had no record of which Stellar public keys belonged to which user. WalletBackup.tsx only offered a local file download, silently implying that storeBackup / getBackup did not exist despite them being in the API client.

Fix:
- Added import { walletAPI } to walletService.ts.
- After walletService.createWallet() persists a new wallet locally, it now calls walletAPI.registerWallet(publicKey, label, network) as a fire-and-forget background request (never sends the secret key — only the public key). Errors are logged as warnings so a transient network failure does not block wallet creation.
- After walletService.importBackup() restores a wallet from backup, it similarly calls walletAPI.registerWallet() to re-register the public key with the backend.
- Updated WalletBackup.tsx to accept an optional serverWalletId prop. After the local file is downloaded successfully, if serverWalletId is provided the component calls walletAPI.storeBackup(serverWalletId, backup) to store the encrypted backup on the server. Server-side failure is caught and logged as a warning so the local backup is never blocked. The success message now tells the user whether the server backup also succeeded.

Files changed: src/lib/wallet/walletService.ts, src/components/Wallet/ WalletBackup.tsx

Closes #760

---

## Issue #761 — UserSession had no isCurrentSession flag; revoke-others could revoke the wrong session

Problem: UserSession (userAPI.ts) had no field identifying which of the listed sessions belonged to the browser making the request. AccountSettings.tsx and account-settings.tsx both used sessions.find((s) => s.isActive) to determine the 'current' session — which merely returns whichever active session is first in the array. With multiple concurrent sessions (phone, laptop, another tab) and no guaranteed array order, this guessing game meant onRevokeOtherSessions() could keep an arbitrary stale session alive and revoke the session the user was actually using, logging them out unexpectedly. The current session was also visually indistinguishable in the UI.

Fix:
- Added isCurrentSession: boolean to the UserSession interface with a JSDoc comment explaining the server-preferred vs. client-derived fallback strategy.
- Updated getAllSessions() in UserManagementAPI: if the backend already sets isCurrentSession on any returned session, the array is used as-is. Otherwise a new private extractSessionIdFromToken() method decodes the JWT access token (no signature verification needed — we trust our own token) and reads the sessionId / session_id / sid claim, then sets isCurrentSession: true on the matching session.
- Updated AccountSettings.tsx Session interface to include isCurrentSession.
- Replaced sessions.find((s) => s.isActive) with sessions.find((s) => s.isCurrentSession) in both handleRevokeSession and handleRevokeOthers in AccountSettings.tsx and account-settings.tsx.
- Updated the sessions list JSX to apply a currentSession CSS class and show a 'This device' badge on the current session entry.
- Added .currentSession and .currentBadge styles to AccountSettings.module.css.

Files changed: src/lib/api/userAPI.ts, src/components/Settings/ AccountSettings.tsx, src/components/Settings/AccountSettings.module.css, src/pages/account-settings.tsx

Closes #761