### PR TITLE
fix: email validation, login error normalization, password strength, remove dead expiry code

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -241,7 +241,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         refreshToken: data.refreshToken,
       });
     } catch (error) {
-      setError(error instanceof Error ? error.message : 'Login failed');
+      const message = error instanceof Error ? error.message : 'Login failed';
+      // Preserve the 2FA sentinel so the caller can branch on it; normalise everything else
+      // to avoid leaking account-state details (user enumeration).
+      setError(message === '2FA_REQUIRED' ? message : 'Invalid email or password. Please try again.');
       throw error;
     } finally {
       setLoading(false);

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -32,10 +32,7 @@ export default function LoginPage() {
       if (err instanceof Error && err.message === '2FA_REQUIRED') {
         setShow2FA(true);
       } else {
-        const msg = err instanceof Error ? err.message : 'Login failed';
-        setError(
-          msg === 'Invalid credentials' ? 'Invalid email or password. Please try again.' : msg
-        );
+        setError('Invalid email or password. Please try again.');
       }
     } finally {
       setIsLoading(false);

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -36,7 +36,11 @@ export default function RegisterPage() {
 
     if (!formData.firstName.trim()) next.firstName = 'First name is required';
     if (!formData.lastName.trim()) next.lastName = 'Last name is required';
-    if (!formData.email.trim()) next.email = 'Email is required';
+    if (!formData.email.trim()) {
+      next.email = 'Email is required';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email.trim())) {
+      next.email = 'Enter a valid email address';
+    }
     if (!/^\+?[1-9]\d{7,14}$/.test(formData.phone.replace(/\s+/g, ''))) {
       next.phone = 'Enter a valid phone number in international format';
     }

--- a/src/utils/passwordPolicy.test.ts
+++ b/src/utils/passwordPolicy.test.ts
@@ -11,7 +11,6 @@ import {
   isPasswordReused,
   savePasswordToHistory,
   clearPasswordHistory,
-  isPasswordExpired,
 } from './passwordPolicy';
 
 // Mock localStorage for Node environment
@@ -89,6 +88,21 @@ test('very weak for short simple password', () => {
   assert.ok(s.score <= 1);
 });
 
+test('short-but-diverse password (under 8 chars) is always Very Weak', () => {
+  // "Ab1!" has uppercase, lowercase, digit, and special char but is only 4 chars —
+  // it must score 0 (Very Weak) because validatePassword would reject it outright.
+  const s = getPasswordStrength('Ab1!');
+  assert.strictEqual(s.score, 0);
+  assert.strictEqual(s.label, 'Very Weak');
+});
+
+test('7-char diverse password is still Very Weak', () => {
+  // One char under the 8-char minimum — diversity must not lift the score.
+  const s = getPasswordStrength('Ab1!xyz');
+  assert.strictEqual(s.score, 0);
+  assert.strictEqual(s.label, 'Very Weak');
+});
+
 test('strong for complex long password', () => {
   const s = getPasswordStrength('MyStr0ng!Pass#2024');
   assert.ok(s.score >= 3);
@@ -134,22 +148,6 @@ test('clearPasswordHistory removes all history', () => {
   savePasswordToHistory('ToBeCleared@1');
   clearPasswordHistory();
   assert.strictEqual(isPasswordReused('ToBeCleared@1'), false);
-});
-
-// ── password expiry (optional) ────────────────────────────────────
-console.log('\npassword expiry');
-
-test('not expired right after saving', () => {
-  clearPasswordHistory();
-  savePasswordToHistory('Fresh@Pass1');
-  assert.strictEqual(isPasswordExpired(), false);
-});
-
-test('expired when timestamp is old', () => {
-  const ninetyOneDaysAgo = (Date.now() - 91 * 24 * 60 * 60 * 1000).toString();
-  store['pw_set_at'] = ninetyOneDaysAgo;
-  assert.strictEqual(isPasswordExpired(), true);
-  clearPasswordHistory();
 });
 
 // ── summary ───────────────────────────────────────────────────────

--- a/src/utils/passwordPolicy.ts
+++ b/src/utils/passwordPolicy.ts
@@ -11,8 +11,6 @@ export interface PasswordValidationResult {
 
 const HISTORY_KEY = 'pw_history';
 const HISTORY_LIMIT = 5;
-const EXPIRY_DAYS = 90;
-const EXPIRY_KEY = 'pw_set_at';
 
 export function validatePassword(password: string): PasswordValidationResult {
   const errors: string[] = [];
@@ -27,6 +25,13 @@ export function validatePassword(password: string): PasswordValidationResult {
 }
 
 export function getPasswordStrength(password: string): PasswordStrength {
+  // Any password that fails the minimum-length requirement is always Very Weak,
+  // regardless of character diversity. This prevents a short-but-diverse password
+  // (e.g. "Ab1!") from scoring as "Fair" when validatePassword would reject it.
+  if (password.length < 8) {
+    return { score: 0, label: 'Very Weak', color: '#ef4444' };
+  }
+
   let score = 0;
   if (password.length >= 8) score++;
   if (password.length >= 12) score++;
@@ -35,7 +40,7 @@ export function getPasswordStrength(password: string): PasswordStrength {
   if (/[^A-Za-z0-9]/.test(password)) score++;
 
   // Clamp to 0-4
-  score = Math.min(4, Math.max(0, score - (password.length < 8 ? 1 : 0)));
+  score = Math.min(4, Math.max(0, score));
 
   const levels: PasswordStrength[] = [
     { score: 0, label: 'Very Weak', color: '#ef4444' },
@@ -70,19 +75,9 @@ export function savePasswordToHistory(password: string): void {
   const hash = simpleHash(password);
   const updated = [hash, ...history.filter((h) => h !== hash)].slice(0, HISTORY_LIMIT);
   localStorage.setItem(HISTORY_KEY, JSON.stringify(updated));
-  localStorage.setItem(EXPIRY_KEY, Date.now().toString());
-}
-
-export function isPasswordExpired(): boolean {
-  if (typeof window === 'undefined') return false;
-  const setAt = localStorage.getItem(EXPIRY_KEY);
-  if (!setAt) return false;
-  const elapsed = Date.now() - parseInt(setAt, 10);
-  return elapsed > EXPIRY_DAYS * 24 * 60 * 60 * 1000;
 }
 
 export function clearPasswordHistory(): void {
   if (typeof window === 'undefined') return;
   localStorage.removeItem(HISTORY_KEY);
-  localStorage.removeItem(EXPIRY_KEY);
 }


### PR DESCRIPTION
## Summary

This PR resolves four frontend security and UX issues: #716, #717, #719, and #720.

---

### #716 — Add email format validation to `register.tsx`

The registration form used `noValidate` and only checked that email was non-empty. Values like `notanemail` or `a b` passed client-side validation and were forwarded to `register()`.

**Change:** Added a `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` regex check in `validate()` after the empty check. Malformed input now shows *'Enter a valid email address'* at the field level and blocks submission.

**File:** `src/pages/register.tsx`

---

### #717 — Normalize login error messages to prevent user enumeration

`AuthContext.login` was storing raw backend error text in state, and `login.tsx` only normalised the exact string `'Invalid credentials'`. Any other distinguishable backend message (e.g. `'User not found'`, `'Account disabled'`) was shown verbatim to unauthenticated visitors, enabling account-state enumeration.

**Change:**
- `AuthContext.login` now normalises every non-`2FA_REQUIRED` error to `'Invalid email or password. Please try again.'` before storing it in state.
- `login.tsx` catch block also normalises unconditionally so both display paths are consistent.
- The `2FA_REQUIRED` sentinel is preserved so the two-factor flow is unaffected.

**Files:** `src/contexts/AuthContext.tsx`, `src/pages/login.tsx`

---

### #719 — Fix `getPasswordStrength` under-penalizing short passwords

The old implementation applied a flat `-1` penalty for passwords under 8 characters, which still allowed a 4-char, all-classes password (e.g. `Ab1!`) to score 2 (`Fair`/yellow). This contradicted the strength checklist directly below the meter, which correctly showed the 8-character rule as unmet.

**Change:** `getPasswordStrength` now returns `score: 0` / `'Very Weak'` immediately for any password shorter than 8 characters, regardless of character diversity. Scoring for valid-length passwords (8–11 chars vs 12+) is unchanged.

Two new regression tests added to `passwordPolicy.test.ts`:
- `'Ab1!'` (4 chars, all classes) → score 0, label `'Very Weak'`
- `'Ab1!xyz'` (7 chars, diverse) → score 0, label `'Very Weak'`

**Files:** `src/utils/passwordPolicy.ts`, `src/utils/passwordPolicy.test.ts`

---

### #720 — Remove dead `isPasswordExpired` code

`isPasswordExpired()` was fully implemented with constants and localStorage writes but was never called from any page, component, or auth flow. It appeared to be an enforced security control while silently doing nothing in production.

**Change:** Removed `isPasswordExpired()`, `EXPIRY_DAYS`, `EXPIRY_KEY`, and the `localStorage.setItem(EXPIRY_KEY, ...)` write inside `savePasswordToHistory()`. `clearPasswordHistory()` updated to no longer reference the removed key. Test file updated to remove the `isPasswordExpired` import and its two test cases.

**Files:** `src/utils/passwordPolicy.ts`, `src/utils/passwordPolicy.test.ts`

---

## Files Changed

| File | Issues |
|------|--------|
| `src/pages/register.tsx` | #716 |
| `src/pages/login.tsx` | #717 |
| `src/contexts/AuthContext.tsx` | #717 |
| `src/utils/passwordPolicy.ts` | #719, #720 |
| `src/utils/passwordPolicy.test.ts` | #719, #720 |

Closes #716
Closes #717
Closes #719
Closes #720