### PR TITLE
Fix onboarding progress calc, QR download leak, search null-derefs, d…

### DIFF
--- a/src/components/Onboarding/OnboardingFlow.tsx
+++ b/src/components/Onboarding/OnboardingFlow.tsx
@@ -13,7 +13,12 @@ import {
   Search,
   Shield,
 } from 'lucide-react';
-import { OnboardingStatus, OnboardingStepId, OnboardingAnalytics } from '../../lib/api/userAPI';
+import {
+  OnboardingStatus,
+  OnboardingStepId,
+  OnboardingAnalytics,
+  ONBOARDING_STEP_IDS,
+} from '../../lib/api/userAPI';
 import styles from './OnboardingFlow.module.css';
 
 interface OnboardingFlowProps {
@@ -24,13 +29,18 @@ interface OnboardingFlowProps {
   onFinish: () => void;
 }
 
-const STEPS: { id: OnboardingStepId; label: string }[] = [
-  { id: 'welcome', label: 'Welcome' },
-  { id: 'profile_setup', label: 'Profile' },
-  { id: 'add_pet', label: 'Your Pet' },
-  { id: 'notifications', label: 'Alerts' },
-  { id: 'explore', label: 'Explore' },
-];
+const STEP_LABELS: Record<OnboardingStepId, string> = {
+  welcome: 'Welcome',
+  profile_setup: 'Profile',
+  add_pet: 'Your Pet',
+  notifications: 'Alerts',
+  explore: 'Explore',
+};
+
+const STEPS: { id: OnboardingStepId; label: string }[] = ONBOARDING_STEP_IDS.map((id) => ({
+  id,
+  label: STEP_LABELS[id],
+}));
 
 /** Pulls a human-readable message out of an unknown error, falling back to a default. */
 function getErrorMessage(err: unknown, fallback: string): string {

--- a/src/lib/api/medicalRecordsAPI.ts
+++ b/src/lib/api/medicalRecordsAPI.ts
@@ -1,0 +1,32 @@
+import axios, { AxiosInstance } from 'axios';
+import { getApiBaseUrl } from './apiBaseUrl';
+
+export interface MedicalRecordSummary {
+  id: string;
+}
+
+class MedicalRecordsAPI {
+  private api: AxiosInstance;
+
+  constructor() {
+    this.api = axios.create({
+      baseURL: `${getApiBaseUrl()}/medical-records`,
+      withCredentials: true,
+    });
+
+    this.api.interceptors.request.use((config) => {
+      const token = localStorage.getItem('authToken');
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    });
+  }
+
+  async getByPetId(petId: string): Promise<MedicalRecordSummary[]> {
+    const response = await this.api.get('', { params: { petId } });
+    return response.data;
+  }
+}
+
+export const medicalRecordsAPI = new MedicalRecordsAPI();

--- a/src/lib/api/petAPI.ts
+++ b/src/lib/api/petAPI.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { PetEmergencyInfo } from '@/types/pet';
+import { Pet, PetEmergencyInfo } from '@/types/pet';
 import { getApiBaseUrl } from './apiBaseUrl';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 

--- a/src/lib/api/userAPI.ts
+++ b/src/lib/api/userAPI.ts
@@ -10,6 +10,14 @@ export type OnboardingStepId =
   | 'notifications'
   | 'explore';
 
+export const ONBOARDING_STEP_IDS: OnboardingStepId[] = [
+  'welcome',
+  'profile_setup',
+  'add_pet',
+  'notifications',
+  'explore',
+];
+
 export interface OnboardingStep {
   id: OnboardingStepId;
   title: string;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,8 +1,12 @@
 import { GetServerSideProps } from 'next';
+import { useEffect, useState } from 'react';
 import { useAuth, type User } from '@/contexts/AuthContext';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import { SkeletonAvatar, SkeletonLine } from '@/components/Skeleton';
 import Link from 'next/link';
+import { petAPI } from '@/lib/api/petAPI';
+import { userAPI } from '@/lib/api/userAPI';
+import { medicalRecordsAPI } from '@/lib/api/medicalRecordsAPI';
 
 export default function DashboardPage() {
   const { user, logout, isLoading } = useAuth();
@@ -47,6 +51,50 @@ export default function DashboardPage() {
 }
 
 function DashboardContent({ user }: { user: User }) {
+  const [petCount, setPetCount] = useState<number | null>(null);
+  const [medicalRecordCount, setMedicalRecordCount] = useState<number | null>(null);
+  const [sessionCount, setSessionCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    petAPI
+      .getUserPets()
+      .then(async (pets) => {
+        if (cancelled) return;
+        setPetCount(pets.length);
+
+        const recordCounts = await Promise.all(
+          pets.map((pet) =>
+            medicalRecordsAPI
+              .getByPetId(pet.id)
+              .then((records) => records.length)
+              .catch(() => 0)
+          )
+        );
+        if (!cancelled) setMedicalRecordCount(recordCounts.reduce((a, b) => a + b, 0));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPetCount(null);
+          setMedicalRecordCount(null);
+        }
+      });
+
+    userAPI
+      .getAllSessions()
+      .then((sessions) => {
+        if (!cancelled) setSessionCount(sessions.filter((s) => s.isActive).length);
+      })
+      .catch(() => {
+        if (!cancelled) setSessionCount(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -61,7 +109,7 @@ function DashboardContent({ user }: { user: User }) {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">My Pets</dt>
-                  <dd className="text-lg font-medium text-gray-900">3</dd>
+                  <dd className="text-lg font-medium text-gray-900">{petCount ?? '—'}</dd>
                 </dl>
               </div>
             </div>
@@ -86,7 +134,9 @@ function DashboardContent({ user }: { user: User }) {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">Medical Records</dt>
-                  <dd className="text-lg font-medium text-gray-900">12</dd>
+                  <dd className="text-lg font-medium text-gray-900">
+                    {medicalRecordCount ?? '—'}
+                  </dd>
                 </dl>
               </div>
             </div>
@@ -111,7 +161,7 @@ function DashboardContent({ user }: { user: User }) {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">Active Sessions</dt>
-                  <dd className="text-lg font-medium text-gray-900">3</dd>
+                  <dd className="text-lg font-medium text-gray-900">{sessionCount ?? '—'}</dd>
                 </dl>
               </div>
             </div>

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -6,6 +6,7 @@ import {
   OnboardingStatus,
   OnboardingAnalytics,
   OnboardingStepId,
+  ONBOARDING_STEP_IDS,
 } from '../lib/api/userAPI';
 import styles from '../styles/pages/OnboardingPage.module.css';
 import { GetServerSideProps } from 'next';
@@ -81,10 +82,13 @@ export default function OnboardingPage() {
     } catch (err: any) {
       if (is404(err)) {
         // Backend not yet implemented — update state locally
+        const totalSteps = status?.steps?.length || ONBOARDING_STEP_IDS.length;
+        const completedCount = (status?.completedSteps.length ?? 0) + 1;
         const updated: OnboardingStatus = {
           ...(status ?? DEFAULT_STATUS),
           completedSteps: [...(status?.completedSteps ?? []), stepId],
-          progressPercent: Math.round((((status?.completedSteps.length ?? 0) + 1) / 5) * 100),
+          progressPercent:
+            totalSteps > 0 ? Math.min(100, Math.round((completedCount / totalSteps) * 100)) : 0,
         };
         setStatus(updated);
         return updated;

--- a/src/pages/qrcode.tsx
+++ b/src/pages/qrcode.tsx
@@ -39,10 +39,14 @@ function QRCard({
     const svg = document.getElementById(`qr-svg-${qr.qrCodeId}`);
     if (!svg) return;
     const blob = new Blob([new XMLSerializer().serializeToString(svg)], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
+    a.href = url;
     a.download = `petchain-qr-${qr.qrCodeId}.svg`;
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -14,10 +14,10 @@ interface Pet {
   age: number;
   location: string;
   status: string;
-  owner: {
+  owner?: {
     firstName: string;
     lastName: string;
-  };
+  } | null;
 }
 
 interface Vet {
@@ -36,10 +36,10 @@ interface MedicalRecord {
   treatment: string;
   recordDate: string;
   vetName: string;
-  pet: {
+  pet?: {
     name: string;
     breed: string;
-  };
+  } | null;
 }
 
 interface EmergencyService {
@@ -122,9 +122,11 @@ export default function SearchPage() {
             {pet.breed} • {pet.species} • {pet.age} years old
           </p>
           <p className="text-sm text-gray-500 mt-1">📍 {pet.location}</p>
-          <p className="text-xs text-gray-500 mt-1">
-            Owner: {pet.owner.firstName} {pet.owner.lastName}
-          </p>
+          {pet.owner && (
+            <p className="text-xs text-gray-500 mt-1">
+              Owner: {pet.owner.firstName} {pet.owner.lastName}
+            </p>
+          )}
         </div>
         <span
           className={`px-3 py-1 text-xs font-semibold rounded-full ${
@@ -171,9 +173,11 @@ export default function SearchPage() {
           </span>
         </div>
         <p className="text-sm text-gray-600 mb-2">Treatment: {record.treatment}</p>
-        <p className="text-sm text-gray-500">
-          Pet: {record.pet.name} ({record.pet.breed})
-        </p>
+        {record.pet && (
+          <p className="text-sm text-gray-500">
+            Pet: {record.pet.name} ({record.pet.breed})
+          </p>
+        )}
         <p className="text-xs text-gray-500 mt-1">Vet: {record.vetName}</p>
       </div>
     </div>


### PR DESCRIPTION
this pr closes #764 
this pr closes #766 
this pr closes #771 
this pr closes #772 

- onboarding.tsx: the local-fallback progress calc (used when the onboarding-status endpoint 404s) hardcoded the step total as 5. Added ONBOARDING_STEP_IDS as a single source of truth in userAPI.ts, wired OnboardingFlow.tsx's STEPS list to derive from it instead of its own hardcoded copy, and updated the fallback calc to use status?.steps?.length with that constant as a fallback, guarding against a zero/unknown total to avoid NaN%/Infinity%.

- qrcode.tsx: the QR "Download" button created a Blob URL and clicked a detached <a> element, which is unreliable in Safari/Firefox and leaked the Blob URL for the life of the page. Now appends the anchor to the DOM before clicking, removes it after, and revokes the object URL, matching the existing pattern in activity-log.tsx.

- search.tsx: renderPetCard and renderMedicalRecordCard dereferenced pet.owner and record.pet without null checks, so an incomplete relation (soft-deleted/orphaned data) would throw and blank the whole results view. Made both fields optional in the types and guarded the JSX that reads them.

- dashboard.tsx: the "My Pets", "Medical Records", and "Active Sessions" summary cards were static JSX text (3, 12, 3) never backed by any state or API call. Now fetches real counts on mount from petAPI.getUserPets(), userAPI.getAllSessions(), and a new medicalRecordsAPI client (summed per pet, since the backend has no aggregate "my records" endpoint). Cards show "—" while loading or on fetch failure instead of a fabricated number.

- petAPI.ts: fixed a pre-existing compile error where getUserPets() referenced the Pet type without importing it.