### PR TITLE
fix(#729): persist vet availability to localStorage and add Save button

### DIFF
--- a/src/components/Appointments/VetAvailabilityList.tsx
+++ b/src/components/Appointments/VetAvailabilityList.tsx
@@ -1,21 +1,67 @@
-import React, { useState } from 'react';
-import { Clock, Check, X, ShieldAlert } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Clock, Check, X, ShieldAlert, Save, Loader2 } from 'lucide-react';
+import { clinicsAPI } from '@/lib/api/clinicsAPI';
 
-export default function VetAvailabilityList() {
-  const [availability, setAvailability] = useState([
-    { day: 'Monday', slots: '09:00 - 17:00', active: true },
-    { day: 'Tuesday', slots: '09:00 - 17:00', active: true },
-    { day: 'Wednesday', slots: '10:00 - 15:00', active: true },
-    { day: 'Thursday', slots: '09:00 - 17:00', active: true },
-    { day: 'Friday', slots: '09:00 - 16:00', active: true },
-    { day: 'Saturday', slots: 'Closed', active: false },
-    { day: 'Sunday', slots: 'Closed', active: false },
-  ]);
+const STORAGE_KEY = 'petchain-vet-availability';
+
+const DEFAULT_AVAILABILITY = [
+  { day: 'Monday', slots: '09:00 - 17:00', active: true },
+  { day: 'Tuesday', slots: '09:00 - 17:00', active: true },
+  { day: 'Wednesday', slots: '10:00 - 15:00', active: true },
+  { day: 'Thursday', slots: '09:00 - 17:00', active: true },
+  { day: 'Friday', slots: '09:00 - 16:00', active: true },
+  { day: 'Saturday', slots: 'Closed', active: false },
+  { day: 'Sunday', slots: 'Closed', active: false },
+];
+
+interface Props {
+  clinicId?: string;
+}
+
+export default function VetAvailabilityList({ clinicId }: Props) {
+  const [availability, setAvailability] = useState(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) return JSON.parse(stored);
+      } catch {
+        // fall through to defaults
+      }
+    }
+    return DEFAULT_AVAILABILITY;
+  });
+
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(availability));
+    } catch {
+      // localStorage unavailable
+    }
+  }, [availability]);
 
   const toggleDay = (index: number) => {
     const newAvail = [...availability];
-    newAvail[index].active = !newAvail[index].active;
+    newAvail[index] = { ...newAvail[index], active: !newAvail[index].active };
     setAvailability(newAvail);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setFeedback(null);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(availability));
+      if (clinicId) {
+        await clinicsAPI.saveAvailability(clinicId, availability);
+      }
+      setFeedback({ type: 'success', message: 'Availability saved successfully.' });
+    } catch {
+      setFeedback({ type: 'error', message: 'Failed to save availability. Please try again.' });
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -29,7 +75,7 @@ export default function VetAvailabilityList() {
       </div>
 
       <div className="space-y-3">
-        {availability.map((day, idx) => (
+        {availability.map((day: { day: string; slots: string; active: boolean }, idx: number) => (
           <div
             key={day.day}
             className={`flex items-center justify-between p-3 rounded-2xl border transition-all ${
@@ -59,6 +105,34 @@ export default function VetAvailabilityList() {
           </div>
         ))}
       </div>
+
+      {feedback && (
+        <div
+          className={`mt-4 p-3 rounded-2xl text-xs font-medium ${
+            feedback.type === 'success'
+              ? 'bg-green-50 text-green-700 border border-green-100'
+              : 'bg-red-50 text-red-700 border border-red-100'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        className="mt-4 w-full py-2.5 bg-blue-600 text-white text-sm font-bold rounded-2xl hover:bg-blue-700 transition-all flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed shadow-lg shadow-blue-100"
+      >
+        {saving ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" /> Saving…
+          </>
+        ) : (
+          <>
+            <Save className="w-4 h-4" /> Save Availability
+          </>
+        )}
+      </button>
 
       <div className="mt-6 p-4 bg-yellow-50 rounded-2xl border border-yellow-100 flex gap-3">
         <ShieldAlert className="w-5 h-5 text-yellow-600 shrink-0" />

--- a/src/lib/api/clinicsAPI.ts
+++ b/src/lib/api/clinicsAPI.ts
@@ -119,6 +119,10 @@ class ClinicsAPI {
     const response = await this.api.get<BackendVetClinic>(`/${id}`);
     return mapVetClinicToClinic(response.data);
   }
+
+  async saveAvailability(clinicId: string, availability: Array<{day: string; slots: string; active: boolean}>): Promise<void> {
+    await this.api.patch(`/${clinicId}/availability`, { availability });
+  }
 }
 
 export const clinicsAPI = new ClinicsAPI();


### PR DESCRIPTION
## Summary
- Add `clinicId?: string` optional prop to `VetAvailabilityList`
- Load initial availability from `localStorage` key `petchain-vet-availability` (falls back to hardcoded defaults)
- Sync availability to `localStorage` on every toggle via `useEffect`
- Add `saveAvailability` method to `ClinicsAPI` in `src/lib/api/clinicsAPI.ts` that calls `PATCH /vet-clinics/:id/availability`
- Add Save button that writes to `localStorage` and, when `clinicId` is provided, calls the API
- Show a spinner while saving and success/error feedback beneath the list

## Test plan
- [ ] Toggle a day off, refresh the page — toggle state is restored from localStorage
- [ ] Click Save without a clinicId — localStorage is written, no API call, success message shown
- [ ] Click Save with a clinicId — API PATCH is called; on network failure, error message shown
- [ ] Saving spinner appears and disables the button while the request is in flight

Closes #729