### PR TITLE
fix(#731): guard ClinicCard location block against empty locations array

### DIFF
--- a/src/components/Clinics/ClinicCard.tsx
+++ b/src/components/Clinics/ClinicCard.tsx
@@ -40,9 +40,14 @@ export default function ClinicCard({ clinic }: ClinicCardProps) {
 
         <div className="flex items-center gap-2 text-xs text-gray-500 mb-3">
           <MapPin className="w-3.5 h-3.5 text-pink-500" />
-          <span className="truncate">
-            {clinic.locations[0].city} (plus {clinic.locations.length - 1} more)
-          </span>
+          {clinic.locations.length > 0 ? (
+            <span className="truncate">
+              {clinic.locations[0].city}
+              {clinic.locations.length > 1 && ` (plus ${clinic.locations.length - 1} more)`}
+            </span>
+          ) : (
+            <span className="truncate text-gray-400">Location unavailable</span>
+          )}
         </div>
 
         <div className="flex flex-wrap gap-2 mb-4">


### PR DESCRIPTION
## Summary
- Replace the bare `clinic.locations[0].city` access in `ClinicCard.tsx` with a guarded block
- When `clinic.locations.length > 0`: shows the first city and, if there are more, appends `(plus N more)`
- When `clinic.locations` is empty: renders `"Location unavailable"` in gray instead of crashing

## Test plan
- [ ] Clinic with zero locations renders without throwing — shows "Location unavailable"
- [ ] Clinic with one location shows the city name with no suffix
- [ ] Clinic with multiple locations shows `city (plus N more)`

Closes #731