### PR TITLE
fix(notifications): eliminate orphaned NotificationList; wire to context

### DIFF
--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -1,77 +1,21 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
+import { useNotifications } from '@/contexts/NotificationContext';
 import { NotificationItem } from './NotificationItem';
-import { notificationsAPI, Notification } from '../../lib/api/notificationsAPI';
 import { BellOff, Loader2, CheckCheck } from 'lucide-react';
 import styles from './NotificationList.module.css';
 
-interface NotificationListProps {
-  userId: string;
-}
-
-export const NotificationList: React.FC<NotificationListProps> = ({ userId }) => {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [unreadCount, setUnreadCount] = useState(0);
-
-  const fetchNotifications = useCallback(async () => {
-    if (!userId) return;
-    setLoading(true);
-    try {
-      const result = await notificationsAPI.getNotifications(userId);
-      setNotifications(result.data);
-      setUnreadCount(result.unreadCount);
-    } catch (err: any) {
-      setError(err.message || 'Failed to load notifications');
-    } finally {
-      setLoading(false);
-    }
-  }, [userId]);
-
-  useEffect(() => {
-    fetchNotifications();
-  }, [fetchNotifications]);
-
-  const handleMarkAsRead = async (id: string) => {
-    try {
-      await notificationsAPI.markAsRead(userId, id);
-      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)));
-      setUnreadCount((prev) => Math.max(0, prev - 1));
-    } catch (err) {
-      console.error('Failed to mark notification as read', err);
-    }
-  };
-
-  const handleMarkAllAsRead = async () => {
-    try {
-      await notificationsAPI.markAllAsRead(userId);
-      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-      setUnreadCount(0);
-    } catch (err) {
-      console.error('Failed to mark all as read', err);
-    }
-  };
+export const NotificationList: React.FC = () => {
+  const { notifications, unreadCount, isLoading, markRead, markAllRead } = useNotifications();
 
   const handleActionClick = (url: string) => {
     window.location.href = url;
   };
 
-  if (loading && notifications.length === 0) {
+  if (isLoading && notifications.length === 0) {
     return (
       <div className={styles.centered}>
         <Loader2 className={styles.spinner} size={32} />
         <p>Loading notifications...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className={styles.centered}>
-        <p className={styles.error}>{error}</p>
-        <button className={styles.retryBtn} onClick={fetchNotifications}>
-          Retry
-        </button>
       </div>
     );
   }
@@ -84,26 +28,25 @@ export const NotificationList: React.FC<NotificationListProps> = ({ userId }) =>
           {unreadCount > 0 && <span className={styles.badge}>{unreadCount} unread</span>}
         </div>
         {unreadCount > 0 && (
-          <button className={styles.markAllBtn} onClick={handleMarkAllAsRead}>
+          <button className={styles.markAllBtn} onClick={markAllRead}>
             <CheckCheck size={16} className={styles.btnIcon} />
             Mark all as read
           </button>
         )}
       </div>
-
       <div className={styles.list}>
         {notifications.length === 0 ? (
           <div className={styles.empty}>
             <BellOff size={48} className={styles.emptyIcon} />
             <h3>No notifications yet</h3>
-            <p>We'll notify you when there's something new.</p>
+            <p>We&apos;ll notify you when there&apos;s something new.</p>
           </div>
         ) : (
           notifications.map((notification) => (
             <NotificationItem
               key={notification.id}
               notification={notification}
-              onMarkAsRead={handleMarkAsRead}
+              onMarkAsRead={markRead}
               onActionClick={handleActionClick}
             />
           ))


### PR DESCRIPTION
## Summary
- Deleted the self-contained fetch loop, local `notifications`/`unreadCount`/`error` state, and direct API calls that duplicated `NotificationContext`
- Component now reads `notifications`, `unreadCount`, `isLoading`, `markRead`, and `markAllRead` from `useNotifications()`
- Removed the `userId` prop — auth is handled internally by the context
- `AppNotification` shape from context is compatible with `NotificationItem` props (id, title, message, category, isRead, createdAt, actionUrl, metadata)

## Test plan
- [ ] Notification list renders items from the context store
- [ ] Marking a notification read via the list updates the context (badge count decreases)
- [ ] "Mark all as read" button updates context correctly
- [ ] No `userId` prop needs to be passed at the call site

Closes #726