### PR TITLE
fix(notifications): seed unreadCount from cache on mount to prevent stale zero

### DIFF
--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -214,7 +214,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
     // Seed from localStorage immediately (offline-first)
     const cached = loadPersisted();
-    if (cached.length) dispatch({ type: 'SET_NOTIFICATIONS', payload: cached });
+    if (cached.length) {
+      dispatch({ type: 'SET_NOTIFICATIONS', payload: cached });
+      dispatch({ type: 'SET_UNREAD', count: cached.filter((n) => !n.isRead).length });
+    }
 
     // Then fetch fresh from API
     dispatch({ type: 'SET_LOADING', value: true });


### PR DESCRIPTION
## Summary

- On mount the load effect dispatched `SET_NOTIFICATIONS` from the localStorage cache but never dispatched `SET_UNREAD`, leaving `unreadCount` stuck at 0 until a successful API response arrived.
- Added a `dispatch({ type: "SET_UNREAD", count: cached.filter((n) => !n.isRead).length })` alongside the existing `SET_NOTIFICATIONS` dispatch in the cache-seed block.
- The `.catch(() => { /* use cached */ })` block in the API fetch chain is now a genuine no-op: the unread count was already set from cached data before the fetch started, so an API failure leaves the correct value in place.

## Test plan

- [ ] First load (cache populated, API succeeds): unread badge shows the count returned by the API.
- [ ] First load (cache populated, API fails/offline): unread badge shows the count computed from cache, not 0.
- [ ] First load (no cache): unread badge shows 0 until API response arrives.

Closes #722