### PR TITLE
fix(breadcrumbs): resolve dynamic segment hrefs using asPath

### DIFF
--- a/src/components/Navigation/Breadcrumbs.tsx
+++ b/src/components/Navigation/Breadcrumbs.tsx
@@ -30,14 +30,23 @@ function labelFor(segment: string) {
 }
 
 export default function Breadcrumbs() {
-  const { pathname } = useRouter();
+  const { pathname, asPath } = useRouter();
 
-  const segments = pathname.split('/').filter(Boolean);
-  if (segments.length === 0) return null;
+  // pathname  → route pattern: /pets/[id]/emergency  (used for labels)
+  // asPath    → resolved URL:  /pets/123/emergency   (used for hrefs)
+  // Strip query string / hash from asPath before splitting
+  const resolvedPath = asPath.split('?')[0].split('#')[0];
 
-  const crumbs = segments.map((seg, i) => ({
+  const patternSegments = pathname.split('/').filter(Boolean);
+  const resolvedSegments = resolvedPath.split('/').filter(Boolean);
+
+  if (patternSegments.length === 0) return null;
+
+  const crumbs = patternSegments.map((seg, i) => ({
     label: labelFor(seg),
-    href: '/' + segments.slice(0, i + 1).join('/'),
+    // Build href from resolved segments so dynamic params are substituted.
+    // Fall back to the pattern segment if asPath somehow has fewer parts.
+    href: '/' + resolvedSegments.slice(0, i + 1).join('/'),
   }));
 
   return (


### PR DESCRIPTION
 
  fix(breadcrumbs): resolve dynamic segment hrefs using asPath
  
  Problem
  
  Breadcrumbs was building crumb hrefs from router.pathname, which is the route
  pattern (e.g. /pets/[id]/emergency), not the resolved URL. On any page with a
  dynamic segment, the intermediate crumb linked to a literal path like
  /pets/[id] — a 404 — instead of the real pet URL like /pets/123.
  
  Changes
  
  - Pull asPath from useRouter() alongside pathname
  - Strip query string and hash from asPath before splitting, so they don't bleed
  into intermediate hrefs
  - Build crumb hrefs from the resolved (asPath) segments — dynamic params are
  substituted with real values
  - Labels continue to derive from pathname pattern segments, so [id] still
  renders as "Details"
  
  Result
  
  On /pets/123/emergency, the breadcrumb trail is:
  
  ┌───────┬───────┬───────────────┬──────────────┐
  │ Crumb │ Label   │ href (before) │ href (after) │
  ├───────┼─────────┼───────────────┼──────────────┤
  │ 1     │ My Pets │ /pets         │ /pets        │
  ├───────┼───────────┼───────────────┼──────────────┤
  │ 2     │ Details   │ /pets/[id] ❌ │ /pets/123 ✅ │
  ├───────┼───────────┼───────────────────────────┼───────────────────────────┤
  │ 3     │ Emergency │ (current page, not        │ (current page, not        │
  │       │           │ linked)                   │ linked)                   │
  └───────┴───────────┴───────────────────────────┴───────────────────────────┘
  
  No breadcrumb href will ever contain literal [ or ] characters.
  
  Files changed
  
  - src/components/Navigation/Breadcrumbs.tsx

closes #736
