### PR TITLE
feat: wire ServiceList Book This button to BookingModal

### DIFF
--- a/src/components/Appointments/BookingModal.tsx
+++ b/src/components/Appointments/BookingModal.tsx
@@ -13,6 +13,8 @@ import { appointmentsAPI } from '@/lib/api/appointmentsAPI';
 
 interface BookingModalProps {
   onClose: () => void;
+  /** Pre-select an appointment type when the modal is opened from a service card. */
+  initialAppointmentType?: AppointmentType;
 }
 
 const APPOINTMENT_TYPES: { value: AppointmentType; label: string; color: string }[] = [
@@ -52,14 +54,14 @@ const TIME_OPTIONS = [
   { value: '15:00', label: '03:00 PM' },
 ];
 
-export default function BookingModal({ onClose }: BookingModalProps) {
+export default function BookingModal({ onClose, initialAppointmentType }: BookingModalProps) {
   const { trigger } = useHaptic();
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const [formData, setFormData] = useState({
     petId: '',
     vetId: '',
-    appointmentType: 'Checkup' as AppointmentType,
+    appointmentType: (initialAppointmentType ?? 'Checkup') as AppointmentType,
     date: '',
     time: '09:00',
     notes: '',

--- a/src/components/Clinics/ServiceList.tsx
+++ b/src/components/Clinics/ServiceList.tsx
@@ -4,9 +4,11 @@ import { Tag } from 'lucide-react';
 
 interface ServiceListProps {
   services: ClinicService[];
+  /** Called when the user clicks "Book This" on a service card. */
+  onBook?: (service: ClinicService) => void;
 }
 
-export default function ServiceList({ services }: ServiceListProps) {
+export default function ServiceList({ services, onBook }: ServiceListProps) {
   return (
     <div className="space-y-4">
       {services.map((service) => (
@@ -35,6 +37,7 @@ export default function ServiceList({ services }: ServiceListProps) {
             </div>
             <button
               type="button"
+              onClick={() => onBook?.(service)}
               className="px-5 py-2.5 bg-gray-900 text-white text-sm font-bold rounded-xl hover:bg-blue-600 transition-all shadow-lg active:scale-95"
             >
               Book This

--- a/src/pages/clinics/[id].tsx
+++ b/src/pages/clinics/[id].tsx
@@ -1,0 +1,358 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+import {
+  MapPin,
+  Phone,
+  Mail,
+  Star,
+  Clock,
+  ArrowLeft,
+  Loader2,
+  AlertCircle,
+} from 'lucide-react';
+import HeaderComponent from '@/components/Header';
+import ServiceList from '@/components/Clinics/ServiceList';
+import StaffList from '@/components/Clinics/StaffList';
+import ReviewSection from '@/components/Clinics/ReviewSection';
+import BookingModal from '@/components/Appointments/BookingModal';
+import SafeImage from '@/components/SafeImage';
+import { Clinic, ClinicService } from '@/types/clinic';
+import { AppointmentType } from '@/types/appointments';
+import { clinicsAPI } from '@/lib/api/clinicsAPI';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort mapping from a service name to one of the fixed AppointmentType
+ * values. Falls back to 'Consultation' so the modal always opens with
+ * something sensible — the user can still change the type inside the modal.
+ */
+function serviceNameToAppointmentType(serviceName: string): AppointmentType {
+  const name = serviceName.toLowerCase();
+  if (name.includes('emergency')) return 'Emergency';
+  if (name.includes('surg')) return 'Surgery';
+  if (name.includes('vaccin') || name.includes('immuni')) return 'Vaccination';
+  if (name.includes('dental') || name.includes('teeth')) return 'Dental';
+  if (name.includes('checkup') || name.includes('check-up') || name.includes('wellness'))
+    return 'Checkup';
+  return 'Consultation';
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+interface ClinicDetailPageProps {
+  clinicId: string;
+}
+
+export default function ClinicDetailPage({ clinicId }: ClinicDetailPageProps) {
+  const [clinic, setClinic] = useState<Clinic | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Booking modal state
+  const [bookingService, setBookingService] = useState<ClinicService | null>(null);
+
+  // Active tab for the detail sections
+  const [activeTab, setActiveTab] = useState<'services' | 'staff' | 'reviews'>('services');
+
+  // ---------------------------------------------------------------------------
+  // Data fetching
+  // ---------------------------------------------------------------------------
+  const loadClinic = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await clinicsAPI.getClinicById(clinicId);
+      setClinic(data);
+    } catch {
+      setError('Could not load clinic details. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [clinicId]);
+
+  useEffect(() => {
+    loadClinic();
+  }, [loadClinic]);
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+  const handleBook = (service: ClinicService) => {
+    setBookingService(service);
+  };
+
+  const handleCloseModal = () => {
+    setBookingService(null);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render helpers
+  // ---------------------------------------------------------------------------
+  const primaryLocation = clinic?.locations[0];
+
+  const tabs: { id: 'services' | 'staff' | 'reviews'; label: string }[] = [
+    { id: 'services', label: 'Services' },
+    { id: 'staff', label: 'Staff' },
+    { id: 'reviews', label: 'Reviews' },
+  ];
+
+  // ---------------------------------------------------------------------------
+  // JSX
+  // ---------------------------------------------------------------------------
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-pink-50 via-blue-50 to-green-50 flex flex-col font-sans text-gray-900">
+      <Head>
+        <title>{clinic ? `${clinic.name} | PetChain` : 'Clinic | PetChain'}</title>
+        <meta
+          name="description"
+          content={
+            clinic
+              ? `Book a veterinary appointment at ${clinic.name}. ${clinic.description}`
+              : 'Veterinary clinic details on PetChain.'
+          }
+        />
+      </Head>
+
+      <HeaderComponent />
+
+      <main className="flex-grow container mx-auto px-4 py-8 max-w-5xl">
+        {/* Back link */}
+        <Link
+          href="/clinics"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 hover:text-blue-700 mb-6 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+          Back to clinics
+        </Link>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Loading state                                                       */}
+        {/* ------------------------------------------------------------------ */}
+        {loading && (
+          <div className="flex flex-col items-center justify-center py-32 text-gray-500">
+            <Loader2 className="w-10 h-10 animate-spin mb-3" />
+            <p>Loading clinic details…</p>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Error state                                                         */}
+        {/* ------------------------------------------------------------------ */}
+        {!loading && error && (
+          <div className="flex flex-col items-center justify-center py-32 gap-4">
+            <AlertCircle className="w-10 h-10 text-red-400" />
+            <p className="text-red-600 font-semibold">{error}</p>
+            <button
+              onClick={loadClinic}
+              className="px-6 py-2.5 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition-colors shadow-lg"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Clinic content                                                      */}
+        {/* ------------------------------------------------------------------ */}
+        {!loading && !error && clinic && (
+          <>
+            {/* Hero card */}
+            <div className="bg-white/80 backdrop-blur-sm rounded-3xl shadow-xl border border-white/40 overflow-hidden mb-8">
+              {/* Cover image */}
+              <div className="relative h-52 md:h-64 w-full bg-blue-100">
+                {clinic.mainImage ? (
+                  <SafeImage
+                    src={clinic.mainImage}
+                    alt={`${clinic.name} clinic`}
+                    fill
+                    sizes="(max-width: 1024px) 100vw, 896px"
+                    className="object-cover"
+                    priority
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center">
+                    <MapPin className="w-16 h-16 text-blue-300" aria-hidden="true" />
+                  </div>
+                )}
+              </div>
+
+              {/* Clinic meta */}
+              <div className="p-6 md:p-8">
+                <div className="flex flex-col md:flex-row md:items-start justify-between gap-4">
+                  <div>
+                    <h1 className="text-3xl font-extrabold text-blue-900 mb-1">{clinic.name}</h1>
+                    <p className="text-gray-600 max-w-2xl leading-relaxed">{clinic.description}</p>
+                  </div>
+
+                  {/* Rating badge */}
+                  <div className="shrink-0 flex items-center gap-1.5 bg-yellow-50 border border-yellow-200 px-4 py-2 rounded-2xl shadow-sm self-start">
+                    <Star className="w-5 h-5 text-yellow-500 fill-yellow-500" aria-hidden="true" />
+                    <span className="font-black text-yellow-700 text-lg">
+                      {clinic.rating > 0 ? clinic.rating.toFixed(1) : 'N/A'}
+                    </span>
+                    {clinic.reviewCount > 0 && (
+                      <span className="text-xs text-yellow-600 font-semibold">
+                        ({clinic.reviewCount})
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Location / contact chips */}
+                {primaryLocation && (
+                  <div className="mt-5 flex flex-wrap gap-3">
+                    <span className="inline-flex items-center gap-1.5 text-sm text-gray-600 bg-gray-50 px-3 py-1.5 rounded-xl border border-gray-100">
+                      <MapPin className="w-4 h-4 text-pink-500 shrink-0" aria-hidden="true" />
+                      {primaryLocation.address}, {primaryLocation.city}
+                    </span>
+                    {primaryLocation.phone && (
+                      <a
+                        href={`tel:${primaryLocation.phone}`}
+                        className="inline-flex items-center gap-1.5 text-sm text-gray-600 bg-gray-50 px-3 py-1.5 rounded-xl border border-gray-100 hover:border-blue-200 hover:text-blue-600 transition-colors"
+                      >
+                        <Phone className="w-4 h-4 text-blue-500 shrink-0" aria-hidden="true" />
+                        {primaryLocation.phone}
+                      </a>
+                    )}
+                    {primaryLocation.email && (
+                      <a
+                        href={`mailto:${primaryLocation.email}`}
+                        className="inline-flex items-center gap-1.5 text-sm text-gray-600 bg-gray-50 px-3 py-1.5 rounded-xl border border-gray-100 hover:border-blue-200 hover:text-blue-600 transition-colors"
+                      >
+                        <Mail className="w-4 h-4 text-blue-500 shrink-0" aria-hidden="true" />
+                        {primaryLocation.email}
+                      </a>
+                    )}
+                    {clinic.hours.some((h) => !h.isClosed) && (
+                      <span className="inline-flex items-center gap-1.5 text-sm text-green-700 bg-green-50 px-3 py-1.5 rounded-xl border border-green-100">
+                        <Clock className="w-4 h-4 shrink-0" aria-hidden="true" />
+                        Open Now
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Tabs */}
+            <div className="flex gap-1 bg-white/60 p-1 rounded-2xl border border-white/40 shadow-sm mb-8 w-fit">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-5 py-2 rounded-xl text-sm font-bold transition-all ${
+                    activeTab === tab.id
+                      ? 'bg-blue-600 text-white shadow-md'
+                      : 'text-gray-600 hover:text-blue-600'
+                  }`}
+                  aria-pressed={activeTab === tab.id}
+                >
+                  {tab.label}
+                  {tab.id === 'services' && clinic.services.length > 0 && (
+                    <span
+                      className={`ml-1.5 text-[10px] font-black px-1.5 py-0.5 rounded-full ${
+                        activeTab === 'services'
+                          ? 'bg-white/20 text-white'
+                          : 'bg-blue-50 text-blue-500'
+                      }`}
+                    >
+                      {clinic.services.length}
+                    </span>
+                  )}
+                  {tab.id === 'staff' && clinic.staff.length > 0 && (
+                    <span
+                      className={`ml-1.5 text-[10px] font-black px-1.5 py-0.5 rounded-full ${
+                        activeTab === 'staff'
+                          ? 'bg-white/20 text-white'
+                          : 'bg-blue-50 text-blue-500'
+                      }`}
+                    >
+                      {clinic.staff.length}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+
+            {/* Tab panels */}
+            {activeTab === 'services' && (
+              <section aria-labelledby="services-heading">
+                <h2 id="services-heading" className="sr-only">
+                  Services offered by {clinic.name}
+                </h2>
+                {clinic.services.length > 0 ? (
+                  <ServiceList services={clinic.services} onBook={handleBook} />
+                ) : (
+                  <p className="text-center text-gray-500 py-12">
+                    No services listed for this clinic yet.
+                  </p>
+                )}
+              </section>
+            )}
+
+            {activeTab === 'staff' && (
+              <section aria-labelledby="staff-heading">
+                <h2 id="staff-heading" className="sr-only">
+                  Staff at {clinic.name}
+                </h2>
+                {clinic.staff.length > 0 ? (
+                  <StaffList staff={clinic.staff} />
+                ) : (
+                  <p className="text-center text-gray-500 py-12">
+                    Staff profiles coming soon.
+                  </p>
+                )}
+              </section>
+            )}
+
+            {activeTab === 'reviews' && (
+              <section aria-labelledby="reviews-heading">
+                <h2 id="reviews-heading" className="sr-only">
+                  Reviews for {clinic.name}
+                </h2>
+                {clinic.reviews && clinic.reviews.length > 0 ? (
+                  <ReviewSection reviews={clinic.reviews} averageRating={clinic.rating} />
+                ) : (
+                  <p className="text-center text-gray-500 py-12">
+                    No reviews yet. Be the first to review this clinic!
+                  </p>
+                )}
+              </section>
+            )}
+          </>
+        )}
+      </main>
+
+      <footer className="text-center text-gray-500 py-10 bg-white/40 border-t border-white/60 mt-auto">
+        <span>© 2024 PetChain Clinic Directory. Premium Care for Every Pet.</span>
+      </footer>
+
+      {/* -------------------------------------------------------------------- */}
+      {/* Booking modal — rendered outside the main layout so it sits on top    */}
+      {/* -------------------------------------------------------------------- */}
+      {bookingService !== null && (
+        <BookingModal
+          onClose={handleCloseModal}
+          initialAppointmentType={serviceNameToAppointmentType(bookingService.name)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Server-side props — just forwards the dynamic segment to the page
+// ---------------------------------------------------------------------------
+export const getServerSideProps: GetServerSideProps<ClinicDetailPageProps> = async (context) => {
+  const { id } = context.params as { id: string };
+  return {
+    props: { clinicId: id },
+  };
+};


### PR DESCRIPTION
feat: wire "Book This" button in ServiceList to BookingModal with pre-selected
  service
  
  Summary
  
  The "Book This" button on each service card in ServiceList had no onClick
  handler, so clicking it did nothing. This PR closes that gap by adding a
  callback prop, creating the missing clinic detail page, and pre-populating the
  booking modal with the selected service's appointment type.
  
  Changes
  
  src/components/Clinics/ServiceList.tsx
  
  Added an onBook?: (service: ClinicService) => void callback prop. The "Book
  This" button now calls onBook?.(service) on click. The prop is optional so
  existing usages without it remain unaffected.
  
  src/components/Appointments/BookingModal.tsx
  
  Added an initialAppointmentType?: AppointmentType prop. When provided, it
  pre-selects the appointment type pill when the modal opens. Falls back to
  'Checkup' if omitted, preserving existing behaviour.
  
  src/pages/clinics/[id].tsx (new file)
  Created the dynamic clinic detail page that ClinicCard already links to
  (/clinics/{id}). The page:
  
  - Fetches clinic data via clinicsAPI.getClinicById(id)
  - Renders tabbed sections: Services, Staff, Reviews
  - Passes onBook to ServiceList; on click, maps the service name to the closest
  AppointmentType (e.g. "Dental" → Dental, "Vaccination" → Vaccination, fallback
  → Consultation) and opens BookingModal pre-populated with that type
  
  Acceptance Criteria
  
  - ✅ Clicking "Book This" on a service opens the booking modal
  - ✅ The modal is pre-populated with the matching appointment type for that
  service

closes #734
