### PR TITLE
Issue resolution

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -18,7 +18,7 @@ export default function ProtectedRoute({
 
   useEffect(() => {
     if (!isLoading && requireAuth && !isAuthenticated) {
-      router.push(redirectTo);
+      router.push(`${redirectTo}?next=${encodeURIComponent(router.asPath)}`);
     }
   }, [isAuthenticated, isLoading, requireAuth, redirectTo, router]);
 

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -12,6 +12,8 @@ export default function ForgotPasswordPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Prevent double-submit
+    if (isLoading) return;
     setIsLoading(true);
     setError('');
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useAuth } from '../contexts/AuthContext';
 import TwoFactorVerify from '../components/Settings/TwoFactorVerify';
 import { TouchInput, TouchButton } from '../components/TouchUI';
+import { isSafeRedirectPath } from '../utils/validation';
 import { GetServerSideProps } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -18,6 +19,12 @@ export default function LoginPage() {
   const { login, loginWith2FA, recoverWith2FA } = useAuth();
   const router = useRouter();
 
+  const getRedirectTarget = () => {
+    const next = router.query.next;
+    if (typeof next === 'string' && isSafeRedirectPath(next)) return next;
+    return '/dashboard';
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     // Prevent double-submit
@@ -27,7 +34,7 @@ export default function LoginPage() {
 
     try {
       await login(email, password);
-      router.push('/dashboard');
+      router.push(getRedirectTarget());
     } catch (err) {
       if (err instanceof Error && err.message === '2FA_REQUIRED') {
         setShow2FA(true);
@@ -41,12 +48,12 @@ export default function LoginPage() {
 
   const handle2FAVerify = async (token: string) => {
     await loginWith2FA(email, password, token);
-    router.push('/dashboard');
+    router.push(getRedirectTarget());
   };
 
   const handle2FARecover = async (backupCode: string) => {
     await recoverWith2FA(email, password, backupCode);
-    router.push('/dashboard');
+    router.push(getRedirectTarget());
   };
 
   if (show2FA) {

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -31,7 +31,7 @@ export default function RegisterPage() {
     if (errors[field]) setErrors((prev) => ({ ...prev, [field]: '' }));
   };
 
-  const validate = (): boolean => {
+  const validate = async (): Promise<boolean> => {
     const next: Partial<typeof formData> = {};
 
     if (!formData.firstName.trim()) next.firstName = 'First name is required';
@@ -47,7 +47,8 @@ export default function RegisterPage() {
 
     const { valid, errors: pwErrors } = validatePassword(formData.password);
     if (!valid) next.password = pwErrors[0];
-    else if (isPasswordReused(formData.password)) next.password = 'This password was used recently';
+    else if (await isPasswordReused(formData.password, formData.email.trim().toLowerCase()))
+      next.password = 'This password was used recently';
 
     if (formData.password !== formData.confirmPassword) {
       next.confirmPassword = 'Passwords do not match';
@@ -61,7 +62,7 @@ export default function RegisterPage() {
     e.preventDefault();
     if (isLoading) return;
     setSubmitError('');
-    if (!validate()) return;
+    if (!(await validate())) return;
 
     setIsLoading(true);
     try {
@@ -72,7 +73,7 @@ export default function RegisterPage() {
         formData.lastName,
         formData.phone
       );
-      savePasswordToHistory(formData.password);
+      await savePasswordToHistory(formData.password, formData.email.trim().toLowerCase());
       router.push(`/verify-account?email=${encodeURIComponent(formData.email)}`);
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Registration failed');

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -54,6 +54,8 @@ export default function ResetPasswordPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Prevent double-submit
+    if (isLoading) return;
     setError('');
 
     if (!(await validateForm())) {

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -13,6 +13,7 @@ export default function ResetPasswordPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
   const [token, setToken] = useState('');
+  const [email, setEmail] = useState('');
   const { resetPassword } = useAuth();
   const router = useRouter();
 
@@ -21,9 +22,12 @@ export default function ResetPasswordPage() {
     if (router.query.token) {
       setToken(router.query.token as string);
     }
-  }, [router.query.token]);
+    if (router.query.email) {
+      setEmail((router.query.email as string).trim().toLowerCase());
+    }
+  }, [router.query.token, router.query.email]);
 
-  const validateForm = () => {
+  const validateForm = async () => {
     if (password !== confirmPassword) {
       setError('Passwords do not match');
       return false;
@@ -35,7 +39,7 @@ export default function ResetPasswordPage() {
       return false;
     }
 
-    if (isPasswordReused(password)) {
+    if (await isPasswordReused(password, email)) {
       setError('This password was used recently. Please choose a different one.');
       return false;
     }
@@ -51,8 +55,8 @@ export default function ResetPasswordPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    
-    if (!validateForm()) {
+
+    if (!(await validateForm())) {
       return;
     }
 
@@ -60,7 +64,7 @@ export default function ResetPasswordPage() {
 
     try {
       await resetPassword(token, password);
-      savePasswordToHistory(password);
+      await savePasswordToHistory(password, email);
       setSuccess(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Password reset failed');

--- a/src/pages/verify-account.tsx
+++ b/src/pages/verify-account.tsx
@@ -6,6 +6,9 @@ import { GetServerSideProps } from 'next';
 
 export const dynamic = 'force-dynamic';
 
+const RESEND_COOLDOWN_SECONDS = 60;
+const MAX_PHONE_ATTEMPTS = 5;
+
 export default function VerifyAccountPage() {
   const router = useRouter();
   const initialEmail = useMemo(() => {
@@ -21,6 +24,10 @@ export default function VerifyAccountPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isResendingEmail, setIsResendingEmail] = useState(false);
   const [isResendingPhone, setIsResendingPhone] = useState(false);
+  const [emailCooldown, setEmailCooldown] = useState(0);
+  const [phoneCooldown, setPhoneCooldown] = useState(0);
+  const [failedPhoneAttempts, setFailedPhoneAttempts] = useState(0);
+  const phoneLocked = failedPhoneAttempts >= MAX_PHONE_ATTEMPTS;
   const { verifyPhone, resendEmailVerification, resendPhoneVerification } = useAuth();
 
   useEffect(() => {
@@ -33,8 +40,21 @@ export default function VerifyAccountPage() {
     }
   }, [router.query.emailVerified]);
 
+  useEffect(() => {
+    if (emailCooldown <= 0) return;
+    const timer = setTimeout(() => setEmailCooldown((s) => s - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [emailCooldown]);
+
+  useEffect(() => {
+    if (phoneCooldown <= 0) return;
+    const timer = setTimeout(() => setPhoneCooldown((s) => s - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [phoneCooldown]);
+
   const handleVerifyPhone = async (event: FormEvent) => {
     event.preventDefault();
+    if (phoneLocked) return;
     if (!email) {
       setError('We could not determine which account to verify.');
       return;
@@ -49,10 +69,12 @@ export default function VerifyAccountPage() {
       setPhoneVerified(result.phoneVerified);
       setEmailVerified(result.emailVerified);
       setMessage(result.message);
+      setFailedPhoneAttempts(0);
       if (result.isVerified) {
         router.push('/login?verified=1');
       }
     } catch (err) {
+      setFailedPhoneAttempts((prev) => prev + 1);
       setError(err instanceof Error ? err.message : 'Phone verification failed');
     } finally {
       setIsSubmitting(false);
@@ -64,6 +86,7 @@ export default function VerifyAccountPage() {
       setError('Enter registration again to request a new email link.');
       return;
     }
+    if (emailCooldown > 0) return;
 
     setIsResendingEmail(true);
     setError('');
@@ -71,6 +94,7 @@ export default function VerifyAccountPage() {
     try {
       await resendEmailVerification(email);
       setMessage('A fresh email verification link has been sent.');
+      setEmailCooldown(RESEND_COOLDOWN_SECONDS);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to resend email verification');
     } finally {
@@ -83,6 +107,7 @@ export default function VerifyAccountPage() {
       setError('Enter registration again to request a new phone code.');
       return;
     }
+    if (phoneCooldown > 0) return;
 
     setIsResendingPhone(true);
     setError('');
@@ -90,6 +115,8 @@ export default function VerifyAccountPage() {
     try {
       await resendPhoneVerification(email);
       setMessage('A new SMS verification code has been sent.');
+      setPhoneCooldown(RESEND_COOLDOWN_SECONDS);
+      setFailedPhoneAttempts(0);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to resend phone verification');
     } finally {
@@ -115,7 +142,8 @@ export default function VerifyAccountPage() {
               type="email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              readOnly={Boolean(initialEmail)}
+              className={`mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 ${initialEmail ? 'bg-gray-100 cursor-not-allowed' : ''}`}
               placeholder="you@example.com"
             />
           </div>
@@ -136,10 +164,14 @@ export default function VerifyAccountPage() {
           <button
             type="button"
             onClick={handleResendEmail}
-            disabled={isResendingEmail}
+            disabled={isResendingEmail || emailCooldown > 0}
             className="w-full rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isResendingEmail ? 'Resending email...' : 'Resend email link'}
+            {isResendingEmail
+              ? 'Resending email...'
+              : emailCooldown > 0
+                ? `Resend available in ${emailCooldown}s`
+                : 'Resend email link'}
           </button>
         </div>
 
@@ -170,14 +202,20 @@ export default function VerifyAccountPage() {
               maxLength={6}
               value={code}
               onChange={(event) => setCode(event.target.value.replace(/\D/g, '').slice(0, 6))}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              disabled={phoneLocked}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
               placeholder="123456"
               required
             />
           </div>
+          {phoneLocked && (
+            <p className="text-sm text-red-600">
+              Too many incorrect codes. Request a new code below to try again.
+            </p>
+          )}
           <button
             type="submit"
-            disabled={isSubmitting}
+            disabled={isSubmitting || phoneLocked}
             className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isSubmitting ? 'Verifying phone...' : 'Verify phone'}
@@ -185,10 +223,14 @@ export default function VerifyAccountPage() {
           <button
             type="button"
             onClick={handleResendPhone}
-            disabled={isResendingPhone}
+            disabled={isResendingPhone || phoneCooldown > 0}
             className="w-full rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isResendingPhone ? 'Resending code...' : 'Resend SMS code'}
+            {isResendingPhone
+              ? 'Resending code...'
+              : phoneCooldown > 0
+                ? `Resend available in ${phoneCooldown}s`
+                : 'Resend SMS code'}
           </button>
         </form>
 

--- a/src/utils/passwordPolicy.test.ts
+++ b/src/utils/passwordPolicy.test.ts
@@ -30,15 +30,19 @@ const mockLocalStorage = {
 let passed = 0;
 let failed = 0;
 
-function test(name: string, fn: () => void) {
-  try {
-    fn();
-    console.log(`  ✓ ${name}`);
-    passed++;
-  } catch (e: unknown) {
-    console.error(`  ✗ ${name}\n    ${(e as Error).message}`);
-    failed++;
-  }
+const tests: Array<() => Promise<void>> = [];
+
+function test(name: string, fn: () => void | Promise<void>) {
+  tests.push(async () => {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (e: unknown) {
+      console.error(`  ✗ ${name}\n    ${(e as Error).message}`);
+      failed++;
+    }
+  });
 }
 
 // ── validatePassword ──────────────────────────────────────────────
@@ -117,39 +121,50 @@ test('returns a label and color', () => {
 // ── password history (last 5) ─────────────────────────────────────
 console.log('\npassword history');
 
-test('new password is not flagged as reused', () => {
+test('new password is not flagged as reused', async () => {
   clearPasswordHistory();
-  assert.strictEqual(isPasswordReused('BrandNew@1'), false);
+  assert.strictEqual(await isPasswordReused('BrandNew@1'), false);
 });
 
-test('saved password is detected as reused', () => {
+test('saved password is detected as reused', async () => {
   clearPasswordHistory();
-  savePasswordToHistory('Reused@Pass1');
-  assert.strictEqual(isPasswordReused('Reused@Pass1'), true);
+  await savePasswordToHistory('Reused@Pass1');
+  assert.strictEqual(await isPasswordReused('Reused@Pass1'), true);
 });
 
-test('different password is not flagged as reused', () => {
+test('different password is not flagged as reused', async () => {
   clearPasswordHistory();
-  savePasswordToHistory('First@Pass1');
-  assert.strictEqual(isPasswordReused('Different@Pass2'), false);
+  await savePasswordToHistory('First@Pass1');
+  assert.strictEqual(await isPasswordReused('Different@Pass2'), false);
 });
 
-test('only last 5 passwords are tracked', () => {
+test('only last 5 passwords are tracked', async () => {
   clearPasswordHistory();
   const passwords = ['Pass@1111', 'Pass@2222', 'Pass@3333', 'Pass@4444', 'Pass@5555', 'Pass@6666'];
-  passwords.forEach(savePasswordToHistory);
+  for (const p of passwords) await savePasswordToHistory(p);
   // oldest (index 0) should be evicted
-  assert.strictEqual(isPasswordReused('Pass@1111'), false);
+  assert.strictEqual(await isPasswordReused('Pass@1111'), false);
   // most recent should still be tracked
-  assert.strictEqual(isPasswordReused('Pass@6666'), true);
+  assert.strictEqual(await isPasswordReused('Pass@6666'), true);
 });
 
-test('clearPasswordHistory removes all history', () => {
-  savePasswordToHistory('ToBeCleared@1');
+test('clearPasswordHistory removes all history', async () => {
+  await savePasswordToHistory('ToBeCleared@1');
   clearPasswordHistory();
-  assert.strictEqual(isPasswordReused('ToBeCleared@1'), false);
+  assert.strictEqual(await isPasswordReused('ToBeCleared@1'), false);
+});
+
+test('history is scoped per identifier', async () => {
+  clearPasswordHistory('userA');
+  clearPasswordHistory('userB');
+  await savePasswordToHistory('Shared@Pass1', 'userA');
+  assert.strictEqual(await isPasswordReused('Shared@Pass1', 'userA'), true);
+  assert.strictEqual(await isPasswordReused('Shared@Pass1', 'userB'), false);
 });
 
 // ── summary ───────────────────────────────────────────────────────
-console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
-if (failed > 0) process.exit(1);
+(async () => {
+  for (const t of tests) await t();
+  console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+})();

--- a/src/utils/passwordPolicy.ts
+++ b/src/utils/passwordPolicy.ts
@@ -9,8 +9,9 @@ export interface PasswordValidationResult {
   errors: string[];
 }
 
-const HISTORY_KEY = 'pw_history';
+const HISTORY_KEY_PREFIX = 'pw_history';
 const HISTORY_LIMIT = 5;
+const DEFAULT_SCOPE = 'anonymous';
 
 export function validatePassword(password: string): PasswordValidationResult {
   const errors: string[] = [];
@@ -53,31 +54,38 @@ export function getPasswordStrength(password: string): PasswordStrength {
   return levels[score] ?? levels[0];
 }
 
-// Simple hash for history comparison (not cryptographic — just for client-side UX)
-function simpleHash(str: string): string {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash << 5) - hash + str.charCodeAt(i);
-    hash |= 0;
-  }
-  return hash.toString(36);
+// NOTE: This is a client-side UX hint only, not a security control. It lives in
+// localStorage, is trivially bypassed by clearing site data or switching browsers/
+// devices, and must never be the sole gate on password reuse — the backend must
+// independently reject reuse of a user's actual password history.
+async function digest(str: string): Promise<string> {
+  const bytes = new TextEncoder().encode(str);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 }
 
-export function isPasswordReused(password: string): boolean {
+function historyKey(scope?: string): string {
+  return `${HISTORY_KEY_PREFIX}:${scope || DEFAULT_SCOPE}`;
+}
+
+export async function isPasswordReused(password: string, scope?: string): Promise<boolean> {
   if (typeof window === 'undefined') return false;
-  const history: string[] = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
-  return history.includes(simpleHash(password));
+  const history: string[] = JSON.parse(localStorage.getItem(historyKey(scope)) || '[]');
+  return history.includes(await digest(password));
 }
 
-export function savePasswordToHistory(password: string): void {
+export async function savePasswordToHistory(password: string, scope?: string): Promise<void> {
   if (typeof window === 'undefined') return;
-  const history: string[] = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
-  const hash = simpleHash(password);
+  const key = historyKey(scope);
+  const history: string[] = JSON.parse(localStorage.getItem(key) || '[]');
+  const hash = await digest(password);
   const updated = [hash, ...history.filter((h) => h !== hash)].slice(0, HISTORY_LIMIT);
-  localStorage.setItem(HISTORY_KEY, JSON.stringify(updated));
+  localStorage.setItem(key, JSON.stringify(updated));
 }
 
-export function clearPasswordHistory(): void {
+export function clearPasswordHistory(scope?: string): void {
   if (typeof window === 'undefined') return;
-  localStorage.removeItem(HISTORY_KEY);
+  localStorage.removeItem(historyKey(scope));
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -5,3 +5,10 @@ export function isValidEmail(value: string): boolean {
 export function isValidPhone(value: string): boolean {
   return /^[\d\s\-+()]+$/.test(value);
 }
+
+// Only allow same-origin relative paths (e.g. "/dashboard/pets/123") as a post-login
+// redirect target, rejecting protocol-relative ("//evil.example.com") or absolute
+// ("https://evil.example.com") values that would otherwise enable an open redirect.
+export function isSafeRedirectPath(value: string): boolean {
+  return /^\/(?!\/)/.test(value);
+}


### PR DESCRIPTION

1. #712 — passwordPolicy.ts now hashes with SHA-256 (crypto.subtle) instead of a 32-bit rolling hash, and the history key is scoped per-email instead of one global key; register.tsx/reset-password.tsx pass the email as scope; added a code comment stating this is a non-authoritative client UX hint (real enforcement belongs server-side, which isn't part of this frontend repo). Updated the existing test file to match the new async signatures.
2. #713 — verify-account.tsx: resend buttons now show a real 60s cooldown after a successful send (not just "while in flight"), failed phone-code attempts are counted and lock the form after 5 wrong tries with a visible message, and the email field becomes read-only when it arrived pre-filled via ?email=.
3. #714 — ProtectedRoute.tsx now appends ?next=<path> when redirecting to login; login.tsx validates next against a new isSafeRedirectPath helper (same-origin relative paths only, rejects // and absolute URLs) and uses it in all three success paths (password, 2FA verify, 2FA recovery), falling back to /dashboard.
4. #715 — Added the if (isLoading) return; guard to forgot-password.tsx and reset-password.tsx, matching login.tsx/register.tsx.

Note on #712: this repo has no backend code, so the "server-side rejects reuse" part of the acceptance criteria is out of scope here — I only addressed the frontend-fixable half (real hash + per-user scoping + documenting it as non-authoritative).

PR description (for when you're ready to push/open it):

Closes #712
Closes #713
Closes #714
Closes #715