### PR TITLE
feat(ci): Extract test, build, and deploy workflows as reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,119 +12,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  frontend-test:
-    name: Frontend Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  test:
+    name: Run All Tests
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      skip-frontend: false
+      skip-backend: false
+      run-coverage: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run frontend tests
-        run: npm test -- --passWithNoTests --ci
-
-      - name: Upload coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-coverage
-          path: coverage/
-          retention-days: 7
-
-  frontend-build:
-    name: Frontend Build
-    runs-on: ubuntu-latest
-    needs: frontend-test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build Next.js (includes type checking)
-        run: npx next build
-
-      - name: Check performance budgets
-        run: |
-          echo "### 📊 Performance Budgets" >> "$GITHUB_STEP_SUMMARY"
-          echo '| Metric | Budget |' >> "$GITHUB_STEP_SUMMARY"
-          echo '|--------|--------|' >> "$GITHUB_STEP_SUMMARY"
-          echo '| LCP | ≤ 2500ms |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| FID | ≤ 100ms |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| CLS | ≤ 0.1 |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| TTFB | ≤ 800ms |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| INP | ≤ 200ms |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| FCP | ≤ 1800ms |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| Lighthouse Performance | ≥ 0.8 |' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo 'Performance budgets are enforced in CI. See `performance-budgets.json` for details.' >> "$GITHUB_STEP_SUMMARY"
-
-  backend-test:
-    name: Backend Tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests with coverage
-        run: npx jest --coverage --passWithNoTests
-
-      - name: Upload coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-coverage
-          path: backend/coverage/
-          retention-days: 7
-
-  backend-build:
-    name: Backend Build
-    runs-on: ubuntu-latest
-    needs: backend-test
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build NestJS
-        run: npx nest build
+  build:
+    name: Build All
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      skip-frontend: false
+      skip-backend: false
+      push-docker: false

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,41 @@
+name: Deploy to Production
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Run Tests
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      skip-frontend: false
+      skip-backend: false
+      run-coverage: false
+
+  build:
+    name: Build All
+    needs: [test]
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      skip-frontend: false
+      skip-backend: false
+      push-docker: true
+      docker-tag: ${{ github.event.release.tag_name || 'latest' }}
+
+  deploy:
+    name: Deploy to Production
+    needs: [test, build]
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: production
+      use-production: true
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,40 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Run Tests
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      skip-frontend: false
+      skip-backend: false
+      run-coverage: false
+
+  build:
+    name: Build All
+    needs: [test]
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      skip-frontend: false
+      skip-backend: false
+      push-docker: false
+
+  deploy:
+    name: Deploy to Staging
+    needs: [test, build]
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: staging
+      use-production: false
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy (Legacy)
 
 on:
   push:
@@ -17,98 +17,20 @@ jobs:
 
   deploy-staging:
     name: Deploy to Staging
-    runs-on: ubuntu-latest
     needs: ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment:
-      name: staging
-      url: ${{ steps.deploy.outputs.url }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel
-
-      - name: Pull Vercel environment (Preview)
-        if: ${{ secrets.VERCEL_TOKEN != '' }}
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Build for staging
-        if: ${{ secrets.VERCEL_TOKEN != '' }}
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Deploy to staging
-        if: ${{ secrets.VERCEL_TOKEN != '' }}
-        id: deploy
-        run: |
-          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "### 🚀 Staging deployed to: $URL" >> "$GITHUB_STEP_SUMMARY"
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    uses: ./.github/workflows/deploy-staging.yml
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
   deploy-production:
     name: Deploy to Production
-    runs-on: ubuntu-latest
     needs: ci
     if: github.event_name == 'release'
-    environment:
-      name: production
-      url: ${{ steps.deploy.outputs.url }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel
-
-      - name: Pull Vercel environment (Production)
-        if: ${{ secrets.VERCEL_TOKEN != '' }}
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Build for production
-        if: ${{ secrets.VERCEL_TOKEN != '' }}
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Deploy to production
-        if: ${{ secrets.VERCEL_TOKEN != '' }}
-        id: deploy
-        run: |
-          URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "### 🚀 Production deployed to: $URL" >> "$GITHUB_STEP_SUMMARY"
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    uses: ./.github/workflows/deploy-production.yml
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,0 +1,147 @@
+name: Reusable Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '20'
+      skip-frontend:
+        description: 'Skip frontend build'
+        required: false
+        type: boolean
+        default: false
+      skip-backend:
+        description: 'Skip backend build'
+        required: false
+        type: boolean
+        default: false
+      docker-registry:
+        description: 'Docker registry'
+        required: false
+        type: string
+        default: 'ghcr.io'
+      docker-image-name:
+        description: 'Docker image name'
+        required: false
+        type: string
+        default: 'petchain-frontend'
+      docker-tag:
+        description: 'Docker image tag'
+        required: false
+        type: string
+        default: 'latest'
+      push-docker:
+        description: 'Push Docker image'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      docker-image:
+        description: 'Built Docker image URI'
+        value: ${{ jobs.docker.outputs.image }}
+
+jobs:
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip-frontend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js
+        run: npx next build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: frontend-build
+          path: .next/
+          retention-days: 7
+
+  backend-build:
+    name: Backend Build
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip-backend }}
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build NestJS
+        run: npx nest build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: backend-build
+          path: backend/dist/
+          retention-days: 7
+
+  docker:
+    name: Docker Build & Push
+    runs-on: ubuntu-latest
+    needs: [frontend-build, backend-build]
+    if: ${{ inputs.push-docker && (needs.frontend-build.result == 'success' || needs.backend-build.result == 'success') }}
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to Docker registry
+        if: ${{ inputs.push-docker }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ inputs.docker-registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ inputs.docker-registry }}/${{ github.repository }}/${{ inputs.docker-image-name }}
+          tags: |
+            type=raw,value=${{ inputs.docker-tag }}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          push: ${{ inputs.push-docker }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -1,0 +1,96 @@
+name: Reusable Deploy Workflow
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        type: string
+        enum: [staging, production]
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '20'
+      vercel-token:
+        description: 'Vercel token secret name'
+        required: false
+        type: string
+        default: 'VERCEL_TOKEN'
+      vercel-org-id:
+        description: 'Vercel org ID secret name'
+        required: false
+        type: string
+        default: 'VERCEL_ORG_ID'
+      vercel-project-id:
+        description: 'Vercel project ID secret name'
+        required: false
+        type: string
+        default: 'VERCEL_PROJECT_ID'
+      use-production:
+        description: 'Use Vercel production environment'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      VERCEL_TOKEN:
+        required: true
+      VERCEL_ORG_ID:
+        required: true
+      VERCEL_PROJECT_ID:
+        required: true
+    outputs:
+      url:
+        description: 'Deployed URL'
+        value: ${{ jobs.deploy.outputs.url }}
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy.outputs.url }}
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel environment
+        if: ${{ secrets.VERCEL_TOKEN != '' }}
+        run: vercel pull --yes --environment=${{ inputs.use-production && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build for ${{ inputs.environment }}
+        if: ${{ secrets.VERCEL_TOKEN != '' }}
+        run: vercel build ${{ inputs.use_production && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to ${{ inputs.environment }}
+        if: ${{ secrets.VERCEL_TOKEN != '' }}
+        id: deploy
+        run: |
+          URL=$(vercel deploy --prebuilt ${{ inputs.use_production && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "### 🚀 ${{ inputs.environment }} deployed to: $URL" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,0 +1,102 @@
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '20'
+      skip-frontend:
+        description: 'Skip frontend tests'
+        required: false
+        type: boolean
+        default: false
+      skip-backend:
+        description: 'Skip backend tests'
+        required: false
+        type: boolean
+        default: false
+      run-coverage:
+        description: 'Generate coverage reports'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      frontend-coverage:
+        description: 'Frontend coverage report path'
+        value: ${{ jobs.frontend-test.outputs.coverage }}
+      backend-coverage:
+        description: 'Backend coverage report path'
+        value: ${{ jobs.backend-test.outputs.coverage }}
+
+jobs:
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip-frontend }}
+    outputs:
+      coverage: ${{ steps.coverage.outputs.path }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test -- --passWithNoTests --ci
+
+      - name: Generate coverage report
+        if: ${{ inputs.run-coverage }}
+        run: npm test -- --coverage --passWithNoTests --ci
+        continue-on-error: true
+
+      - name: Upload coverage report
+        if: ${{ inputs.run-coverage && always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: frontend-coverage
+          path: coverage/
+          retention-days: 7
+
+  backend-test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip-backend }}
+    outputs:
+      coverage: ${{ steps.coverage.outputs.path }}
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npx jest --coverage --passWithNoTests
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: backend-coverage
+          path: backend/coverage/
+          retention-days: 7

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -1,0 +1,195 @@
+# Reusable Workflow Interface
+
+This document describes the reusable GitHub Actions workflows and their interfaces.
+
+## Overview
+
+The CI/CD pipeline is composed of three reusable workflows:
+
+1. **reusable-test.yml** - Test workflow for frontend and backend
+2. **reusable-build.yml** - Build workflow for frontend, backend, and Docker
+3. **reusable-deploy.yml** - Deploy workflow for different environments
+
+## Reusable Test Workflow
+
+**File:** `.github/workflows/reusable-test.yml`
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `node-version` | string | No | `20` | Node.js version |
+| `skip-frontend` | boolean | No | `false` | Skip frontend tests |
+| `skip-backend` | boolean | No | `false` | Skip backend tests |
+| `run-coverage` | boolean | No | `true` | Generate coverage reports |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `frontend-coverage` | Frontend coverage report path |
+| `backend-coverage` | Backend coverage report path |
+
+### Example Usage
+
+```yaml
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      node-version: '20'
+      skip-frontend: false
+      skip-backend: false
+      run-coverage: true
+```
+
+## Reusable Build Workflow
+
+**File:** `.github/workflows/reusable-build.yml`
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `node-version` | string | No | `20` | Node.js version |
+| `skip-frontend` | boolean | No | `false` | Skip frontend build |
+| `skip-backend` | boolean | No | `false` | Skip backend build |
+| `docker-registry` | string | No | `ghcr.io` | Docker registry |
+| `docker-image-name` | string | No | `petchain-frontend` | Docker image name |
+| `docker-tag` | string | No | `latest` | Docker image tag |
+| `push-docker` | boolean | No | `false` | Push Docker image |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `docker-image` | Built Docker image URI |
+
+### Example Usage
+
+```yaml
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      node-version: '20'
+      push-docker: true
+      docker-tag: production-${{ github.sha }}
+```
+
+## Reusable Deploy Workflow
+
+**File:** `.github/workflows/reusable-deploy.yml`
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `environment` | string | Yes | - | Deployment environment (staging, production) |
+| `node-version` | string | No | `20` | Node.js version |
+| `use-production` | boolean | No | `false` | Use Vercel production environment |
+
+### Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `VERCEL_TOKEN` | Yes | Vercel authentication token |
+| `VERCEL_ORG_ID` | Yes | Vercel organization ID |
+| `VERCEL_PROJECT_ID` | Yes | Vercel project ID |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `url` | Deployed URL |
+
+### Example Usage
+
+```yaml
+jobs:
+  deploy:
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: staging
+      use-production: false
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+```
+
+## Caller Workflows
+
+The repository includes the following caller workflows:
+
+| Workflow | File | Description |
+|----------|------|-------------|
+| CI | `ci.yml` | Main CI pipeline (test + build) |
+| Deploy Staging | `deploy-staging.yml` | Deploy to staging environment |
+| Deploy Production | `deploy-production.yml` | Deploy to production environment |
+| Deploy (Legacy) | `deploy.yml` | Legacy deploy workflow using reusable workflows |
+
+## Action Version Pinning
+
+All GitHub Actions are pinned to specific commit SHAs for security and reproducibility:
+
+| Action | Pinned Version |
+|--------|----------------|
+| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) |
+| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4) |
+| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4) |
+| `docker/setup-buildx-action` | `b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2` (v3.10.0) |
+| `docker/login-action` | `74a5d142397b4f367a81961eba4e8cd7edddf772` (v3.4.0) |
+| `docker/metadata-action` | `902fa8ec7d6ecbf8d84d538b9b233a880e428804` (v5.7.0) |
+| `docker/build-push-action` | `14487ce63c7a62a4a324b0bfb37086795e31c6c1` (v6.16.0) |
+
+## Environment Configuration
+
+Each environment requires the following GitHub repository secrets:
+
+### Staging
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+### Production
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+## Creating a New Caller Workflow
+
+To create a new caller workflow for a custom environment:
+
+1. Create a new file in `.github/workflows/` (e.g., `deploy-dev.yml`)
+2. Use the `workflow_call` trigger to invoke reusable workflows
+3. Configure the appropriate secrets for the environment
+
+Example:
+
+```yaml
+name: Deploy to Dev
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      run-coverage: false
+
+  build:
+    uses: ./.github/workflows/reusable-build.yml
+
+  deploy:
+    needs: [test, build]
+    uses: ./.github/workflows/reusable-deploy.yml
+    with:
+      environment: staging
+      use-production: false
+    secrets:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+```


### PR DESCRIPTION
## Summary
Extract test, build, and deploy workflows as reusable GitHub Actions workflows.

## Changes
- Extract test workflow as reusable ()
- Extract build workflow as reusable ()
- Extract deploy workflow as reusable ()
- Create caller workflows for each environment (staging, production)
- Document reusable workflow interface ()
- Add version pinning for all GitHub Actions

## Benefits
- Reusable workflows reduce duplication across environments
- Version pinning ensures reproducible builds
- Clear separation of concerns between test, build, and deploy stages
- Easy to add new environments by creating new caller workflows

Closes #750
Closes #749
Closes #748
Closes #747