### PR TITLE
fix: resolve notification priority drift, debounce leak, and GDPR dea…

### DIFF
--- a/src/components/Navigation/NavSearch.tsx
+++ b/src/components/Navigation/NavSearch.tsx
@@ -40,6 +40,11 @@ export default function NavSearch({ onClose, autoFocus }: NavSearchProps) {
     []
   );
 
+  // Cancel any pending debounce on unmount to prevent setState after unmount
+  useEffect(() => {
+    return () => fetchSuggestions.cancel();
+  }, [fetchSuggestions]);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
     setOpen(true);

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -88,13 +88,17 @@ export default function SearchBar({
     }
   };
 
-  // Debounced autocomplete
+  // Debounced autocomplete — cancel on unmount to prevent setState after unmount
   const debouncedFetchSuggestions = useCallback(
     debounce((searchQuery: unknown) => {
       fetchSuggestions(searchQuery as string);
     }, 300),
     [searchType]
   );
+
+  useEffect(() => {
+    return () => debouncedFetchSuggestions.cancel();
+  }, [debouncedFetchSuggestions]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;

--- a/src/components/Settings/GdprSettings.tsx
+++ b/src/components/Settings/GdprSettings.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import { useGdpr } from '@/hooks/useGdpr';
+import type { ConsentType } from '@/lib/gdpr';
+
+interface GdprSettingsProps {
+  userId: string;
+}
+
+const CONSENT_LABELS: Record<ConsentType, { label: string; description: string }> = {
+  essential: {
+    label: 'Essential',
+    description: 'Required for core functionality. Cannot be disabled.',
+  },
+  analytics: {
+    label: 'Analytics',
+    description: 'Help us improve PetChain by sharing anonymous usage data.',
+  },
+  marketing: {
+    label: 'Marketing',
+    description: 'Receive personalised tips, offers, and news about PetChain.',
+  },
+  data_sharing: {
+    label: 'Data Sharing',
+    description: 'Allow sharing anonymised data with trusted veterinary research partners.',
+  },
+};
+
+export default function GdprSettings({ userId }: GdprSettingsProps) {
+  const { consents, loading, error, updateConsent, exportData, requestDeletion } =
+    useGdpr(userId);
+  const [deletionReason, setDeletionReason] = useState('');
+  const [showDeletionForm, setShowDeletionForm] = useState(false);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+
+  const handleToggle = async (type: ConsentType, granted: boolean) => {
+    if (type === 'essential') return; // essential consent is immutable
+    await updateConsent(type, granted);
+  };
+
+  const handleExport = async () => {
+    await exportData();
+    setActionFeedback('Your data export has started. The download will begin shortly.');
+    setTimeout(() => setActionFeedback(null), 5000);
+  };
+
+  const handleDeletionRequest = async () => {
+    const result = await requestDeletion(deletionReason || undefined);
+    if (result) {
+      setShowDeletionForm(false);
+      setDeletionReason('');
+      setActionFeedback(`Deletion request submitted (ID: ${result.id}). Status: ${result.status}.`);
+      setTimeout(() => setActionFeedback(null), 8000);
+    }
+  };
+
+  return (
+    <section aria-labelledby="gdpr-heading">
+      <h2 id="gdpr-heading" className="text-lg font-semibold text-gray-900 mb-1">
+        Privacy &amp; Data Rights
+      </h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Manage your GDPR consent preferences and exercise your data rights.
+      </p>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-600 mb-3">
+          {error}
+        </p>
+      )}
+
+      {actionFeedback && (
+        <p role="status" className="text-sm text-green-700 bg-green-50 rounded-lg px-3 py-2 mb-3">
+          {actionFeedback}
+        </p>
+      )}
+
+      {/* Consent toggles */}
+      <div className="divide-y divide-gray-100 border border-gray-200 rounded-lg mb-4">
+        {(Object.keys(CONSENT_LABELS) as ConsentType[]).map((type) => {
+          const consent = consents.find((c) => c.type === type);
+          const isEssential = type === 'essential';
+          const checked = isEssential ? true : (consent?.granted ?? false);
+
+          return (
+            <div key={type} className="flex items-start justify-between px-4 py-3 gap-4">
+              <div>
+                <p className="text-sm font-medium text-gray-800">
+                  {CONSENT_LABELS[type].label}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">{CONSENT_LABELS[type].description}</p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={checked}
+                aria-label={`${CONSENT_LABELS[type].label} consent`}
+                disabled={isEssential || loading}
+                onClick={() => handleToggle(type, !checked)}
+                className={`mt-0.5 relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  checked ? 'bg-blue-600' : 'bg-gray-300'
+                } ${isEssential ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                    checked ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Data rights actions */}
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={handleExport}
+          disabled={loading}
+          className="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded-lg hover:bg-blue-100 disabled:opacity-50 transition-colors"
+        >
+          Export My Data
+        </button>
+        <button
+          onClick={() => setShowDeletionForm((v) => !v)}
+          className="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 rounded-lg hover:bg-red-100 transition-colors"
+        >
+          Request Account Erasure
+        </button>
+      </div>
+
+      {showDeletionForm && (
+        <div className="mt-3 p-4 border border-red-200 rounded-lg bg-red-50">
+          <p className="text-sm text-red-800 font-medium mb-2">
+            This will permanently delete your account and all associated data. This action cannot
+            be undone.
+          </p>
+          <textarea
+            value={deletionReason}
+            onChange={(e) => setDeletionReason(e.target.value)}
+            placeholder="Optional: reason for erasure request"
+            rows={3}
+            className="w-full text-sm px-3 py-2 border border-red-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 bg-white mb-3"
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleDeletionRequest}
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+            >
+              Confirm Erasure Request
+            </button>
+            <button
+              onClick={() => setShowDeletionForm(false)}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -233,7 +233,13 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     notificationsAPI
       .getNotifications(user.id)
       .then((res) => {
-        const ns = res.data as AppNotification[];
+        // Map API Notification → AppNotification, defaulting priority when absent
+        // (older backend responses may omit it).
+        const ns: AppNotification[] = res.data.map((n) => ({
+          ...n,
+          priority: n.priority ?? 'normal',
+          metadata: n.metadata as AppNotification['metadata'],
+        }));
         dispatch({ type: 'SET_NOTIFICATIONS', payload: ns });
         dispatch({ type: 'SET_UNREAD', count: res.unreadCount });
         persistNotifications(ns);

--- a/src/lib/api/notificationsAPI.ts
+++ b/src/lib/api/notificationsAPI.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { getApiBaseUrl } from './apiBaseUrl';
 import type { NotificationPreferences } from '@/types/notification';
+export type { NotificationPriority } from '@/types/notification';
 
 export type NotificationCategory =
   | 'APPOINTMENT'
@@ -35,6 +36,7 @@ export interface Notification {
   title: string;
   message: string;
   category: NotificationCategory;
+  priority: NotificationPriority;
   isRead: boolean;
   readAt: string | null;
   actionUrl: string | null;
@@ -42,6 +44,8 @@ export interface Notification {
   createdAt: string;
   updatedAt: string;
 }
+
+export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
 
 export interface RegisterDeviceTokenDto {
   token: string;

--- a/src/pages/account-settings.tsx
+++ b/src/pages/account-settings.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { AccountSettings } from '../components/Settings/AccountSettings';
 import TwoFactorSettings from '../components/Settings/TwoFactorSettings';
+import GdprSettings from '../components/Settings/GdprSettings';
 import { userAPI, UserSession, ActivityLog } from '../lib/api/userAPI';
 import { useAuth } from '../contexts/AuthContext';
 import { twoFactorAPI } from '../lib/api/twoFactorAPI';
@@ -225,6 +226,12 @@ export default function AccountSettingsPage() {
       <div className={styles.section}>
         <TwoFactorSettings />
       </div>
+
+      {auth.user && (
+        <div className={styles.section}>
+          <GdprSettings userId={auth.user.id} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,18 +1,29 @@
+export interface DebouncedFn<T extends (...args: unknown[]) => unknown> {
+  (...args: Parameters<T>): void;
+  /** Cancel any pending invocation without executing the underlying function. */
+  cancel(): void;
+}
+
 export function debounce<T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number
-): (...args: Parameters<T>) => void {
+): DebouncedFn<T> {
   let timeout: NodeJS.Timeout | null = null;
 
-  return function executedFunction(...args: Parameters<T>) {
-    const later = () => {
+  function executedFunction(...args: Parameters<T>) {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => {
       timeout = null;
       func(...args);
-    };
+    }, wait);
+  }
 
+  executedFunction.cancel = () => {
     if (timeout) {
       clearTimeout(timeout);
+      timeout = null;
     }
-    timeout = setTimeout(later, wait);
   };
+
+  return executedFunction;
 }


### PR DESCRIPTION
This PR resolves three separate but related frontend issues that were silently breaking runtime behaviour, causing memory leaks, and leaving a complete compliance feature unreachable by users.

---

### #753 — notificationsAPI \`Notification\` type missing \`priority\` field

The \`Notification\` interface in \`src/lib/api/notificationsAPI.ts\` did not declare a \`priority\` field, while \`AppNotification\` in \`src/types/notification.ts\` requires \`priority: NotificationPriority\`. \`NotificationContext.tsx\` was bridging the gap with an unchecked \`as AppNotification[]\` cast, so at runtime \`notif.priority\` was silently \`undefined\`, breaking DND bypass logic and urgent-notification handling (sound frequency, sticky toast duration, vibration pattern).

**Changes:**
- Added \`priority: NotificationPriority\` to the \`Notification\` interface in \`notificationsAPI.ts\`
- Added \`NotificationPriority\` type inline and re-exported it from \`@/types/notification\`
- Replaced the unsafe \`as AppNotification[]\` cast in \`NotificationContext.tsx\` with an explicit mapping that also defaults \`priority\` to \`'normal'\` for any older API responses that may omit the field

Closes #753

---

### #752 — \`debounce()\` has no cancel mechanism, causing stale results and setState-after-unmount

\`src/utils/debounce.ts\` exposed no way for callers to cancel a pending invocation. Both \`SearchBar.tsx\` and \`NavSearch.tsx\` created a debounced fetch on mount and never cleaned it up, so a pending autocomplete call could fire \`setState\` after the component had already unmounted.

**Changes:**
- Extended \`debounce\` to return a \`DebouncedFn\` with a \`.cancel()\` method that clears the pending timeout
- Added a cleanup \`useEffect\` in \`SearchBar.tsx\` that calls \`debouncedFetchSuggestions.cancel()\` on unmount
- Added the same cleanup \`useEffect\` in \`NavSearch.tsx\`

Closes #752

---

### #751 — Entire GDPR consent/export/deletion system was dead code

\`src/lib/gdpr.ts\`, \`src/hooks/useGdpr.ts\`, and the three Next.js API proxy routes under \`src/pages/api/gdpr/[userId]/\` were fully implemented but never imported by any page or component. Users had no way to manage granular consent, export their data, or request account erasure through this system.

**Changes:**
- Created \`src/components/Settings/GdprSettings.tsx\` — a self-contained section component that renders toggles for each \`ConsentType\` (essential/analytics/marketing/data_sharing), an \"Export My Data\" button, and a guarded \"Request Account Erasure\" form with an optional reason field
- Wired \`GdprSettings\` into \`src/pages/account-settings.tsx\`, passing \`auth.user.id\` so the hook can load and persist real consent state

Closes #751 

Closes #754

---

## Testing
- Verify DND correctly bypasses urgent notifications (priority \`'urgent'\` should always show toast/sound even during DND hours)
- Rapidly type in \`SearchBar\` or \`NavSearch\`, then navigate away — no console warnings about setState on unmounted component
- On \`/account-settings\`, the Privacy & Data Rights section should render consent toggles populated from the API, and both Export and Erasure flows should be reachable" 2>&1